### PR TITLE
add topics

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,8 @@ class ApplicationController < ActionController::Base
   include Authentication
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  def check_admin!
+    redirect_to root_path unless Current.user.is_admin?
+  end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,0 +1,61 @@
+class TopicsController < ApplicationController
+  before_action :set_topic, only: [ :show, :edit, :update, :destroy, :archive ]
+  before_action :check_admin!, only: :destroy
+
+  def index
+    @topics = scope.includes(:language, :provider)
+  end
+
+  def new
+    @topic = scope.new
+  end
+
+  def create
+    @topic = scope.new(topic_params)
+
+    if @topic.save
+      redirect_to topics_path
+    else
+      render :new
+    end
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    @topic.update(topic_params)
+    redirect_to topics_path
+  end
+
+  def destroy
+    @topic.destroy
+    redirect_to topics_path
+  end
+
+  def archive
+    @topic.archived!
+    redirect_to topics_path
+  end
+
+  private
+
+  def topic_params
+    params.require(:topic).permit(:title, :description, :uid, :language_id, :provider_id)
+  end
+
+  def set_topic
+    @topic = Topic.find(params[:id])
+  end
+
+  def scope
+    @scope ||= if Current.user.is_admin?
+      Topic.all
+    else
+      Topic.active
+    end
+  end
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,12 @@
+class Topic < ApplicationRecord
+  belongs_to :language
+  belongs_to :provider
+
+  validates :title, :language_id, :provider_id, presence: true
+
+  STATES = %i[active archived].freeze
+
+  enum :state, STATES.map.with_index.to_h
+
+  scope :active, -> { where(state: :active) }
+end

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -59,10 +59,10 @@
         </li>
 
         <li class="sidebar-item">
-          <a href="ui-file-uploader.html" class="sidebar-link">
+          <%= link_to topics_path, class: "sidebar-link" do %>
             <i class="bi bi-tags-fill"></i>
             <span>Topics</span>
-          </a>
+          <% end %>
         </li>
 
         <li class="sidebar-item">

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,6 +1,6 @@
 <% if resource.errors.any? %>
   <div style="color: red">
-    <h4><%= "#{pluralize(resource.errors.count, "error")} prohibited this #{resource.class_name} from being saved:" %>></h4>
+    <h4><%= "#{pluralize(resource.errors.count, "error")} prohibited this #{resource.class.name} from being saved:" %>></h4>
     <ul>
       <% resource.errors.each do |error| %>
         <li><%= error.full_message %></li>

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -1,0 +1,34 @@
+
+<%= form_for topic do |f| %>
+  <div class="form-body">
+    <div class="row">
+      <%= render "shared/errors", resource: topic %>
+      <div class="col-12">
+        <div class="form-group">
+          <%= f.label :title %>
+          <%= f.text_field :title, class: "form-control", placeholder: "Title" %>
+        </div>
+        <div class="form-group">
+          <%= f.label :description %>
+          <%= f.text_area :description, class: "form-control", placeholder: "Descripion" %>
+        </div>
+        <div class="form-group">
+          <%= f.label :language %>
+          <%= f.collection_select :language_id, Language.all, :id, :name, { prompt: "Select Language" }, class: "form-select" %>
+        </div>
+        <div class="form-group">
+          <%= f.label :provider %>
+          <%= f.collection_select :provider_id, Provider.all, :id, :name, { prompt: "Select Provider" }, class: "form-select" %>
+        </div>
+        <div class="form-group">
+          <%= f.label :description %>
+          <%= f.text_area :description, class: "form-control", placeholder: "Descripion" %>
+        </div>
+        <div class="col-12 d-flex justify-content-end">
+          <%= f.submit "Save", class: "btn btn-primary me-1 mb-1" %>
+          <%= link_to "Cancel", topics_path, class: "btn btn-light-secondary me-1 mb-1" %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/topics/_topic.html.erb
+++ b/app/views/topics/_topic.html.erb
@@ -1,0 +1,26 @@
+<div id="<%= dom_id topic %>">
+  <p>
+    <strong>Title:</strong>
+    <%= topic.title %>
+  </p>
+
+  <p>
+    <strong>Description:</strong>
+    <%= topic.description %>
+  </p>
+
+  <p>
+    <strong>UID:</strong>
+    <%= topic.uid %>
+  </p>
+
+  <p>
+    <strong>Language:</strong>
+    <%= link_to topic.language.name, topic.language %>
+  </p>
+
+  <p>
+    <strong>Provider:</strong>
+    <%= link_to topic.provider.name, topic.provider %>
+  </p>
+</div>

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, "Editing topic" %>
+
+<section id="basic-vertical-layouts">
+  <div class="row match-height">
+    <div class="col-md-6 col-12">
+      <div class="card">
+        <div class="card-header">
+          <h2 class="card-title">Edit topic</h2>
+        </div>
+        <div class="card-content">
+          <div class="card-body">
+            <%= render "form", topic: @topic %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,0 +1,64 @@
+<% content_for :title, "Topics" %>
+
+<section class="section">
+  <div class="row" id="table-striped">
+    <div class="col-12 cold-md-12">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h2 class="card-title">Topics</h2>
+          <%= link_to new_topic_path, class: "btn btn-primary" do %>
+            <i class="bi bi-plus"></i> Add New Topic
+          <% end %>
+        </div>
+        <div class="card-content">
+          <div class="card-body">
+            <p class="card-text"> Some important information or instruction can be placed here.</p>
+            <div class="table-responsive">
+              <table class="table table-lg table-striped mb-0">
+                <thead>
+                  <tr>
+                    <th>Title</th>
+                    <th>Description</th>
+                    <th>UID</th>
+                    <th>Language</th>
+                    <th>Provider</th>
+                    <th>State</th>
+                    <th class="text-end">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% @topics.each do |topic| %>
+                    <tr>
+                      <td class="text-bold-500"><%= topic.title %></td>
+                      <td class="text-bold-500"><%= topic.description.truncate(25, omission: "...") %></td>
+                      <td class="text-bold-500"><%= topic.uid.truncate(10, omission: "...") %></td>
+                      <td class="text-bold-500"><%= topic.language.name %></td>
+                      <td class="text-bold-500"><%= topic.provider.name %></td>
+                      <td class="text-bold-500"><%= topic.state %></td>
+                      <td class="text-end">
+                        <%= link_to topic, class: "btn btn-primary btn-sm" do %>
+                          <i class="bi bi-search"></i> View
+                        <% end %>
+                        <%= link_to edit_topic_path(topic), class: "btn btn-secondary btn-sm" do %>
+                          <i class="bi bi-pencil"></i> Edit
+                        <% end %>
+                        <%= link_to archive_topic_path(topic), method: :put, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm" do %>
+                          <i class="bi bi-archive"></i> Archive
+                        <% end %>
+                        <% if Current.user.is_admin? %>
+                          <%= link_to topic, method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm" do %>
+                            <i class="bi bi-trash"></i> Delete
+                          <% end %>
+                        <% end %>
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, "New topic" %>
+
+<section id="basic-vertical-layouts">
+  <div class="row match-height">
+    <div class="col-md-6 col-12">
+      <div class="card">
+        <div class="card-header">
+          <h2 class="card-title">New topic</h2>
+        </div>
+        <div class="card-content">
+          <div class="card-body">
+            <%= render "form", topic: @topic %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,0 +1,18 @@
+<div style="color: green"><%= notice %></div>
+
+<%= render @topic %>
+
+<div class="mt-4">
+  <%= link_to "Edit this topic", edit_topic_path(@topic) %> |
+  <%= link_to "Back to topics", topics_path %>
+</div>
+
+<div>
+  <%= button_to "Archive this topic", archive_topic_path(@topic), method: :put, class: "btn btn-danger mt-4" %>
+</div>
+
+<% if Current.user.is_admin? %>
+  <div>
+    <%= button_to "Delete this topic", @topic, method: :delete, class: "btn btn-danger mt-4" %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
   resource :registration, only: %i[new create]
   resource :session
   resources :users
+  resources :topics do
+    put :archive, on: :member
+  end
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest

--- a/db/migrate/20250204140110_create_topics.rb
+++ b/db/migrate/20250204140110_create_topics.rb
@@ -1,0 +1,14 @@
+class CreateTopics < ActiveRecord::Migration[8.0]
+  def change
+    create_table :topics do |t|
+      t.references :provider
+      t.references :language
+      t.string :title, null: false
+      t.text :description, null: false
+      t.uuid :uid, default: 'gen_random_uuid()', null: false
+      t.integer :state, default: 0, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_04_084321) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_04_140110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
-
-  create_table "languages", force: :cascade do |t|
-    t.string "name"
-    t.string "file_share_folder"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
   create_table "branches", force: :cascade do |t|
     t.bigint "provider_id"
@@ -28,6 +21,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_04_084321) do
     t.datetime "updated_at", null: false
     t.index ["provider_id"], name: "index_branches_on_provider_id"
     t.index ["region_id"], name: "index_branches_on_region_id"
+  end
+
+  create_table "languages", force: :cascade do |t|
+    t.string "name"
+    t.string "file_share_folder"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "providers", force: :cascade do |t|
@@ -50,6 +50,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_04_084321) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
+  create_table "topics", force: :cascade do |t|
+    t.bigint "provider_id"
+    t.bigint "language_id"
+    t.string "title", null: false
+    t.text "description", null: false
+    t.uuid "uid", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "state", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["language_id"], name: "index_topics_on_language_id"
+    t.index ["provider_id"], name: "index_topics_on_provider_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,3 +14,30 @@
 ].each do |language|
   Language.find_or_create_by!(language)
 end
+
+[
+  { name: "Provided by the government", provider_type: "government" },
+].each do |provider|
+  Provider.find_or_create_by!(provider)
+end
+
+[
+  {
+    title: "Introduction to English",
+    description: "Learn the basics of English",
+    language_id: Language.find_by(name: "english").id,
+    provider_id: Provider.find_by(name: "Provided by the government").id,
+    uid: "d290f1ee-6c54-4b01-90e6-d701748f0851",
+    state: :active,
+  },
+  {
+    title: "Introduction to Spanish",
+    description: "Learn the basics of Spanish",
+    language_id: Language.find_by(name: "spanish").id,
+    provider_id: Provider.find_by(name: "Provided by the government").id,
+    uid: "d290f1ee-6c54-4b01-90e6-d701748f0852",
+    state: :archived,
+  },
+].each do |topic|
+  Topic.find_or_create_by!(topic)
+end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :topic do
+    association :provider
+    association :language
+    title { "topic" }
+    description { "details" }
+    uid { SecureRandom.uuid }
+    state { 0 }
+
+    trait :archived do
+      state { 1 }
+    end
+  end
+end

--- a/spec/requests/topics/archive_spec.rb
+++ b/spec/requests/topics/archive_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "Topics", type: :request do
+  describe "PUT /topics/:id" do
+    let(:user) { create(:user) }
+    let(:topic) { create(:topic) }
+
+    before { sign_in(user) }
+
+    it "archives a Topic" do
+      put archive_topic_url(topic)
+
+      expect(response).to redirect_to(topics_url)
+      expect(topic.reload.state).to eq("archived")
+    end
+  end
+end

--- a/spec/requests/topics/create_spec.rb
+++ b/spec/requests/topics/create_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe "Topics", type: :request do
+  describe "POST /topics" do
+    let(:user) { create(:user) }
+    let(:provider) { create(:provider) }
+    let(:language) { create(:language) }
+    let(:topic_params) { attributes_for(:topic, provider_id: provider.id, language_id: language.id) }
+
+    before { sign_in(user) }
+
+    it "creates a Topic" do
+      post topics_url, params: { topic: topic_params }
+
+      expect(response).to redirect_to(topics_url)
+      topic = Topic.last
+      expect(topic.title).to eq("topic")
+      expect(topic.description).to eq("details")
+      expect(topic.state).to eq("active")
+    end
+  end
+end

--- a/spec/requests/topics/destroy_spec.rb
+++ b/spec/requests/topics/destroy_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe "Topics", type: :request do
+  describe "DELETE /topics/:id" do
+    let(:user) { create(:user, :admin) }
+    let(:topic) { create(:topic) }
+
+    before { sign_in(user) }
+
+    it "deletes a Topic" do
+      delete topic_url(topic)
+
+      expect(response).to redirect_to(topics_url)
+      expect(Topic.count).to be_zero
+    end
+
+    context "when user is not ad admin" do
+      let(:user) { create(:user) }
+
+      it "does not delete a Topic" do
+        delete topic_url(topic)
+
+        expect(response).to redirect_to(root_url)
+        expect(Topic.count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/requests/topics/index_spec.rb
+++ b/spec/requests/topics/index_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe "Topics", type: :request do
+  describe "GET /topics" do
+    let(:user) { create(:user) }
+
+    before { sign_in(user) }
+
+    it "renders a successful response" do
+      create(:topic)
+
+      get topics_url
+
+      expect(response).to be_successful
+      expect(assigns(:topics)).to eq(Topic.active)
+    end
+  end
+end

--- a/spec/requests/topics/update_spec.rb
+++ b/spec/requests/topics/update_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe "Topics", type: :request do
+  describe "PUT /topics/:id" do
+    let(:user) { create(:user) }
+
+    before { sign_in(user) }
+
+    it "updates a Language" do
+      topic = create(:topic)
+      topic_params = { title: "new topic", description: "updated" }
+
+      put topic_url(topic), params: { topic: topic_params }
+
+      topic.reload
+      expect(response).to redirect_to(topics_url)
+      expect(topic.title).to eq("new topic")
+      expect(topic.description).to eq("updated")
+    end
+  end
+end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #018

### What Changed? And Why Did It Change?

Added basic CRUD actions for topics + archive option.
Provider specific listing is not implemented since it does belong to #19 

### How Has This Been Tested?

Using request specs

### Please Provide Screenshots

<img width="427" alt="Screenshot 2025-02-04 at 16 35 20" src="https://github.com/user-attachments/assets/dbfb7e95-3012-4074-bae8-df220e163b6e" />
<img width="1129" alt="Screenshot 2025-02-04 at 16 35 26" src="https://github.com/user-attachments/assets/e19969da-430a-497f-8169-deda406e690e" />
<img width="590" alt="Screenshot 2025-02-04 at 16 35 31" src="https://github.com/user-attachments/assets/939abf9a-05f9-4ae8-873f-1d0df06620f7" />

### Additional Comments

* used `gen_random_uuid` generator for `uid` since details were not specified
* using integer `state` for topics, so "archived" is one of the states
* since other states (except active/archived were not specified), this fields is not manageable: topic is always created active