### PR TITLE
add search for for topics

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -51,16 +51,9 @@ class TopicsController < ApplicationController
 
   helper_method :search_params
   def search_params
-    default_search_params
-      .then do |def_params|
-        params[:search].present? ? def_params.merge(
-          params.require(:search).permit(:query, :state, :provider_id, :language_id, :year, :month, :order).to_h.symbolize_keys,
-        ) : def_params
-      end
-  end
+    return {} unless params[:search].present?
 
-  def default_search_params
-    { query: nil, state: nil, provider_id: nil, language_id: nil, year: nil, month: nil, order: :desc }
+    params.require(:search).permit(:query, :state, :provider_id, :language_id, :year, :month, :order)
   end
 
   def set_topic

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -3,7 +3,10 @@ class TopicsController < ApplicationController
   before_action :check_admin!, only: :destroy
 
   def index
-    @topics = scope.includes(:language, :provider)
+    @topics = scope.search_with_params(search_params)
+    @search = Topic::SEARCH.new(**search_params)
+    @providers = scope.map(&:provider).uniq.sort_by(&:name)
+    @languages = scope.map(&:language).uniq.sort_by(&:name)
   end
 
   def new
@@ -47,6 +50,19 @@ class TopicsController < ApplicationController
     params.require(:topic).permit(:title, :description, :uid, :language_id, :provider_id)
   end
 
+  def search_params
+    default_search_params
+      .then do |def_params|
+        params[:search].present? ? def_params.merge(
+          params.require(:search).permit(:query, :state, :provider_id, :language_id, :year, :month, :order).to_h.symbolize_keys,
+        ) : def_params
+      end
+  end
+
+  def default_search_params
+    { query: nil, state: nil, provider_id: nil, language_id: nil, year: nil, month: nil, order: :desc }
+  end
+
   def set_topic
     @topic = Topic.find(params[:id])
   end
@@ -55,7 +71,7 @@ class TopicsController < ApplicationController
     @scope ||= if Current.user.is_admin?
       Topic.all
     else
-      Topic.active
-    end
+      Current.user.topics
+    end.includes(:language, :provider)
   end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -4,7 +4,6 @@ class TopicsController < ApplicationController
 
   def index
     @topics = scope.search_with_params(search_params)
-    @search = Topic::SEARCH.new(**search_params)
     @providers = scope.map(&:provider).uniq.sort_by(&:name)
     @languages = scope.map(&:language).uniq.sort_by(&:name)
   end
@@ -50,6 +49,7 @@ class TopicsController < ApplicationController
     params.require(:topic).permit(:title, :description, :uid, :language_id, :provider_id)
   end
 
+  helper_method :search_params
   def search_params
     default_search_params
       .then do |def_params|

--- a/app/models/concerns/searcheable.rb
+++ b/app/models/concerns/searcheable.rb
@@ -1,0 +1,49 @@
+module Searcheable
+  extend ActiveSupport::Concern
+
+  SEARCH = Data.define(:query, :state, :provider_id, :language_id, :year, :month, :order)
+  SORTS = %i[asc desc].freeze
+
+  class_methods do
+    def search(query)
+      where("title ILIKE :query OR description ILIKE :query", query: "%#{query}%")
+    end
+
+    def by_year(year)
+      where("extract(year from created_at) = ?", year)
+    end
+
+    def by_month(month)
+      where("extract(month from created_at) = ?", month)
+    end
+
+    def by_provider(provider_id)
+      where(provider_id: provider_id)
+    end
+
+    def by_language(language_id)
+      where(language_id: language_id)
+    end
+
+    def by_state(state)
+      where(state: state)
+    end
+
+    def order(order_from_params)
+      return :desc unless SORTS.include?(order_from_params)
+
+      order_from_params
+    end
+
+    def search_with_params(params)
+      self
+        .then { |scope| params[:state].present? ? scope.by_state(params[:state]) : scope }
+        .then { |scope| params[:provider_id].present? ? scope.by_provider(params[:provider_id]) : scope }
+        .then { |scope| params[:language_id].present? ? scope.by_language(params[:language_id]): scope }
+        .then { |scope| params[:year].present? ? scope.by_year(params[:year]) : scope }
+        .then { |scope| params[:month].present? ? scope.by_month(params[:month]) : scope }
+        .then { |scope| params[:query].present? ? scope.search(params[:query]) : scope }
+        .then { |scope| scope.order(created_at: order(params[:order])) }
+    end
+  end
+end

--- a/app/models/concerns/searcheable.rb
+++ b/app/models/concerns/searcheable.rb
@@ -1,7 +1,6 @@
 module Searcheable
   extend ActiveSupport::Concern
 
-  SEARCH = Data.define(:query, :state, :provider_id, :language_id, :year, :month, :order)
   SORTS = %i[asc desc].freeze
 
   class_methods do
@@ -29,7 +28,7 @@ module Searcheable
       where(state: state)
     end
 
-    def order(order_from_params)
+    def sort_order(order_from_params)
       return :desc unless SORTS.include?(order_from_params)
 
       order_from_params
@@ -43,7 +42,7 @@ module Searcheable
         .then { |scope| params[:year].present? ? scope.by_year(params[:year]) : scope }
         .then { |scope| params[:month].present? ? scope.by_month(params[:month]) : scope }
         .then { |scope| params[:query].present? ? scope.search(params[:query]) : scope }
-        .then { |scope| scope.order(created_at: order(params[:order])) }
+        .then { |scope| scope.order(created_at: sort_order(params[:order])) }
     end
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,4 +1,6 @@
 class Topic < ApplicationRecord
+  include Searcheable
+
   belongs_to :language
   belongs_to :provider
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true, format: URI::MailTo::EMAIL_REGEXP
   validates :password_digest, presence: true
+
+  def topics
+    Topic.where(provider_id: providers.pluck(:id))
+  end
 end

--- a/app/views/topics/_search.html.erb
+++ b/app/views/topics/_search.html.erb
@@ -35,7 +35,7 @@
               </div>
               <div class="form-group">
                 <%= f.label :order %>
-                <%= f.select :order, options_for_select(Topic::SORTS.index_with(&:itself), params[:order]), { prompt: "Select order" }, class: "form-select" %>
+                <%= f.select :order, options_for_select(Topic::SORTS.reverse.index_with(&:itself), params[:order]), {}, class: "form-select" %>
               </div>
               <div class="col-12 d-flex justify-content-end">
                 <%= f.submit "Search", class: "btn btn-primary me-1 mb-1" %>

--- a/app/views/topics/_search.html.erb
+++ b/app/views/topics/_search.html.erb
@@ -11,19 +11,19 @@
             <div class="col-12">
               <div class="form-group">
                 <%= f.label :provider %>
-                <%= f.collection_select :provider_id, providers, :id, :name, { prompt: "Select provider" }, class: "form-select" %>
+                <%= f.select :provider_id, options_from_collection_for_select(providers, :id, :name, params[:provider_id]), { prompt: "Select provider" }, class: "form-select" %>
               </div>
               <div class="form-group">
                 <%= f.label :language %>
-                <%= f.collection_select :language_id, languages, :id, :name, { prompt: "Select language" }, class: "form-select" %>
+                <%= f.select :language_id, options_from_collection_for_select(languages, :id, :name, params[:provider_id]),  { prompt: "Select language" }, class: "form-select" %>
               </div>
               <div class="form-group">
                 <%= f.label :query %>
-                <%= f.text_field :query, class: "form-control" %>
+                <%= f.text_field :query, value: params[:query], class: "form-control" %>
               </div>
               <div class="form-group">
                 <%= f.label :year %>
-                <%= f.select :year, options_for_select((Date.today.year-10..Date.today.year).to_a, params[:year].to_i), { prompt: "Select year" }, class: "form-select" %>
+                <%= f.select :year, options_for_select((Date.today.year-10..Date.today.year).to_a, params[:year]), { prompt: "Select year" }, class: "form-select" %>
               </div>
               <div class="form-group">
                 <%= f.label :month %>

--- a/app/views/topics/_search.html.erb
+++ b/app/views/topics/_search.html.erb
@@ -1,0 +1,50 @@
+<div class="card">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h2 class="card-title">Search</h2>
+  </div>
+  <div class="card-content">
+    <div class="card-body">
+      <p class="card-text"> Use these params settings to search topics</p>
+      <%= form_for :search, url: topics_path, method: :get do |f| %>
+        <div class="form-body">
+          <div class="row">
+            <div class="col-12">
+              <div class="form-group">
+                <%= f.label :provider %>
+                <%= f.collection_select :provider_id, providers, :id, :name, { prompt: "Select provider" }, class: "form-select" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :language %>
+                <%= f.collection_select :language_id, languages, :id, :name, { prompt: "Select language" }, class: "form-select" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :query %>
+                <%= f.text_field :query, class: "form-control" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :year %>
+                <%= f.select :year, options_for_select((Date.today.year-10..Date.today.year).to_a, params[:year].to_i), { prompt: "Select year" }, class: "form-select" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :month %>
+                <%= f.select :month, options_for_select((1..12).to_a, params[:month]), { prompt: "Select month" }, class: "form-select" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :state %>
+                <%= f.select :state, options_for_select(Topic::STATES.index_with(&:itself), params[:state]), { prompt: "Select state" }, class: "form-select" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :order %>
+                <%= f.select :order, options_for_select(Topic::SORTS.index_with(&:itself), params[:order]), { prompt: "Select order" }, class: "form-select" %>
+              </div>
+              <div class="col-12 d-flex justify-content-end">
+                <%= f.submit "Search", class: "btn btn-primary me-1 mb-1" %>
+                <%= link_to "Clear", topics_path, class: "btn btn-light-secondary me-1 mb-1" %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -3,6 +3,7 @@
 <section class="section">
   <div class="row" id="table-striped">
     <div class="col-12 cold-md-12">
+      <%= render "topics/search", providers: @providers, languages: @languages  %>
       <div class="card">
         <div class="card-header d-flex justify-content-between align-items-center">
           <h2 class="card-title">Topics</h2>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -3,7 +3,7 @@
 <section class="section">
   <div class="row" id="table-striped">
     <div class="col-12 cold-md-12">
-      <%= render "topics/search", providers: @providers, languages: @languages  %>
+      <%= render "topics/search", providers: @providers, languages: @languages, params: search_params  %>
       <div class="card">
         <div class="card-header d-flex justify-content-between align-items-center">
           <h2 class="card-title">Topics</h2>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -43,8 +43,10 @@
                         <%= link_to edit_topic_path(topic), class: "btn btn-secondary btn-sm" do %>
                           <i class="bi bi-pencil"></i> Edit
                         <% end %>
-                        <%= link_to archive_topic_path(topic), method: :put, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm" do %>
-                          <i class="bi bi-archive"></i> Archive
+                        <% unless topic.archived? %>
+                          <%= link_to archive_topic_path(topic), method: :put, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm" do %>
+                            <i class="bi bi-archive"></i> Archive
+                          <% end %>
                         <% end %>
                         <% if Current.user.is_admin? %>
                           <%= link_to topic, method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm" do %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,7 +59,11 @@ end
 puts "Topics created!"
 puts "Creating users..."
 
-User.create(email: "me@mail.com", password: "test123")
+User.create(email: "admin@mail.com", password: "test123", is_admin: true)
+me = User.create(email: "me@mail.com", password: "test123")
+Provider.each do |provider|
+  provider.users << me
+end
 
 10.times do
   User.create(

--- a/spec/factories/contributor.rb
+++ b/spec/factories/contributor.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :contributor do
+    association :provider
+    association :user
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -2,12 +2,5 @@ FactoryBot.define do
   factory :provider do
     name { "ACME" }
     provider_type { "provider" }
-
-    trait :with_user do
-      after(:create) do |provider|
-        user = create(:user)
-        provider.contributors.create(user: user)
-      end
-    end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -2,5 +2,12 @@ FactoryBot.define do
   factory :provider do
     name { "ACME" }
     provider_type { "provider" }
+
+    trait :with_user do
+      after(:create) do |provider|
+        user = create(:user)
+        provider.contributors.create(user: user)
+      end
+    end
   end
 end

--- a/spec/requests/topics/index_spec.rb
+++ b/spec/requests/topics/index_spec.rb
@@ -2,17 +2,80 @@ require "rails_helper"
 
 describe "Topics", type: :request do
   describe "GET /topics" do
+    let(:provider) { create(:provider, :with_user) }
     let(:user) { create(:user) }
 
-    before { sign_in(user) }
+    before do
+      provider.users << user
+      sign_in(user)
+    end
 
     it "renders a successful response" do
-      create(:topic)
+      topic = create(:topic, provider:)
 
       get topics_url
 
       expect(response).to be_successful
-      expect(assigns(:topics)).to eq(Topic.active)
+      expect(assigns(:topics)).to eq([ topic ])
+    end
+
+    describe "searching" do
+      context "with a query" do
+        it "filters topics by query" do
+          topic = create(:topic, provider:, title: "Introduction to English")
+
+          get topics_url, params: { search: { query: "English" } }
+
+          expect(response).to be_successful
+          expect(assigns(:topics)).to eq([ topic ])
+        end
+      end
+
+      context "with a state" do
+        it "filters topics by state" do
+          active_topic = create(:topic, provider:, state: :active)
+          archived_topic = create(:topic, provider:, state: :archived)
+
+          get topics_url, params: { search: { state: "active" } }
+
+          expect(response).to be_successful
+          expect(assigns(:topics)).to eq([ active_topic ])
+        end
+      end
+
+      context "by provider" do
+        it "filters topics by provider" do
+          topic = create(:topic, provider:)
+
+          get topics_url, params: { search: { provider_id: provider.id } }
+
+          expect(response).to be_successful
+          expect(assigns(:topics)).to eq([ topic ])
+        end
+      end
+
+      context "by language" do
+        it "filters topics by language" do
+          language = create(:language)
+          topic = create(:topic, provider:, language:)
+
+          get topics_url, params: { search: { language_id: language.id } }
+
+          expect(response).to be_successful
+          expect(assigns(:topics)).to eq([ topic ])
+        end
+      end
+
+      context "by year and month" do
+        it "filters topics by date" do
+          topic = create(:topic, provider:, created_at: Time.zone.local(2021, 1, 1))
+
+          get topics_url, params: { search: { year: 2021, month: 1 } }
+
+          expect(response).to be_successful
+          expect(assigns(:topics)).to eq([ topic ])
+        end
+      end
     end
   end
 end

--- a/spec/requests/topics/index_spec.rb
+++ b/spec/requests/topics/index_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Topics", type: :request do
   describe "GET /topics" do
-    let(:provider) { create(:provider, :with_user) }
+    let(:provider) { create(:provider) }
     let(:user) { create(:user) }
 
     before do


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #019

### What Changed? And Why Did It Change?

This PR Introduces form for topic search.
For now it requires pushing "Submit" button, but later I will try to make it work without.
We use existing `GET topics` route here and several attributes to filter for

### How Has This Been Tested?

Added new request specs for `GET topics` with different search options

### Please Provide Screenshots

<img width="1136" alt="Screenshot 2025-02-05 at 16 21 12" src="https://github.com/user-attachments/assets/8c6dc7f7-51dc-4493-9b71-8a3308acf386" />

### Additional Comments

One more thing we can do here is to introduce [choices](https://github.com/Choices-js/Choices) for new selectors that we have. But probably it is better to add separate issues for that
