### PR TITLE
change logic for sign_in test helper

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,4 +58,11 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  BCrypt::Engine.cost = BCrypt::Engine::MIN_COST
+
+  unless ENV["TEST_LOGS"]
+    config.logger = Logger.new(nil)
+    config.log_level = :fatal
+  end
 end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,6 +1,8 @@
 module AuthenticationHelpers
   def sign_in(user)
-    post session_url, params: { email: user.email, password: user.password }
+    Current.session = user.sessions.create!
+    cookies = ActionDispatch::Request.new(Rails.application.env_config).cookie_jar
+    cookies.signed[:session_id] = { value: Current.session.id, httponly: true, same_site: :lax }
   end
 end
 


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

This PR makes CI build faster

### What Changed? And Why Did It Change?

* omit logging and some security for test env
* do not send request for request `sign_in` helper

### How Has This Been Tested?

With running CI build

### Additional Comments

Ideas from [thoughtbot article](https://thoughtbot.com/blog/things-you-might-not-need-in-your-tests)
