### PR TITLE
Add file_storage_prefix to Language

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,8 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
     nokogiri (1.18.2-aarch64-linux-gnu)

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -31,7 +31,7 @@ class LanguagesController < ApplicationController
   private
 
   def language_params
-    params.require(:language).permit(:name, :file_share_folder)
+    params.require(:language).permit(:name)
   end
 
   def set_language

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,3 +1,4 @@
 class Language < ApplicationRecord
   validates :name, :file_share_folder, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,4 +1,9 @@
 class Language < ApplicationRecord
-  validates :name, :file_share_folder, presence: true, uniqueness: true
   validates :name, presence: true, uniqueness: true
+
+  def file_storage_prefix
+    return "" if name == "English" || name.nil?
+
+    "#{name.first(2).upcase}_"
+  end
 end

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -8,10 +8,6 @@
           <%= f.label :name %>
           <%= f.text_field :name, class: "form-control", placeholder: "Name" %>
         </div>
-        <div class="form-group">
-          <%= f.label :file_share_folder %>
-          <%= f.text_field :file_share_folder, class: "form-control", placeholder: "Folder" %>
-        </div>
         <div class="col-12 d-flex justify-content-end">
           <%= f.submit "Save", class: "btn btn-primary me-1 mb-1" %>
           <%= link_to "Cancel", languages_path, class: "btn btn-light-secondary me-1 mb-1" %>

--- a/app/views/languages/index.html.erb
+++ b/app/views/languages/index.html.erb
@@ -26,7 +26,7 @@
                   <% @languages.each do |language| %>
                     <tr>
                       <td class="text-bold-500"><%= language.name %></td>
-                      <td class="text-bold-500"><%= language.file_share_folder %></td>
+                      <td class="text-bold-500"><%= language.file_storage_prefix %></td>
                       <td class="text-end">
                         <%= link_to edit_language_path(language), class: "btn btn-secondary btn-sm" do %>
                           <i class="bi bi-pencil"></i> Edit

--- a/db/migrate/20250222124508_remove_file_share_folder_from_languages.rb
+++ b/db/migrate/20250222124508_remove_file_share_folder_from_languages.rb
@@ -1,0 +1,5 @@
+class RemoveFileShareFolderFromLanguages < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :languages, :file_share_folder
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_04_141359) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_22_124508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -62,7 +62,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_04_141359) do
 
   create_table "languages", force: :cascade do |t|
     t.string "name"
-    t.string "file_share_folder"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,7 +61,7 @@ puts "Creating users..."
 
 User.create(email: "admin@mail.com", password: "test123", is_admin: true)
 me = User.create(email: "me@mail.com", password: "test123")
-Provider.each do |provider|
+Provider.all.each do |provider|
   provider.users << me
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,8 +17,8 @@ User.destroy_all
 puts "Creating languages..."
 
 [
-  { name: "english", file_share_folder: "languages/english" },
-  { name: "spanish", file_share_folder: "languages/spanish" },
+  { name: "english" },
+  { name: "spanish" },
 ].each do |language|
   Language.find_or_create_by!(language)
 end

--- a/spec/factories/languages.rb
+++ b/spec/factories/languages.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :language do
     name { Faker::Name.name }
-    file_share_folder { Faker::File.dir }
   end
 end

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Language, type: :model do
+  subject { create(:language, name: name) }
+
+  context "validations" do
+    let(:name) { Faker::Name.name }
+    it { should validate_presence_of(:name) }
+  end
+
+  describe ".file_storage_prefix" do
+    context "when storage_prefix is English" do
+      let(:name) { "English" }
+
+      it "returns an empty string" do
+        expect(subject.file_storage_prefix).to eq("")
+      end
+    end
+
+    context "when storage_prefix is different than English" do
+      let(:name) { "French" }
+
+      it "returns a string with the first two characters of the name, capitalized, followed by an underscore" do
+        expect(subject.file_storage_prefix).to eq("FR_")
+      end
+    end
+  end
+end

--- a/spec/requests/languages/create_spec.rb
+++ b/spec/requests/languages/create_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Languages", type: :request do
   describe "POST /languages" do
     let(:user) { create(:user, :admin) }
-    let(:language_params) { { name: "french", file_share_folder: "languages/french" } }
+    let(:language_params) { { name: "french" } }
 
     before { sign_in(user) }
 

--- a/spec/requests/languages/create_spec.rb
+++ b/spec/requests/languages/create_spec.rb
@@ -12,7 +12,7 @@ describe "Languages", type: :request do
 
       expect(response).to redirect_to(languages_path)
       expect(Language.last.name).to eq("french")
-      expect(Language.last.file_share_folder).to eq("languages/french")
+      expect(Language.last.file_storage_prefix).to eq("FR_")
     end
   end
 end

--- a/spec/requests/languages/update_spec.rb
+++ b/spec/requests/languages/update_spec.rb
@@ -15,7 +15,7 @@ describe "Languages", type: :request do
       language.reload
       expect(response).to redirect_to(languages_path)
       expect(language.name).to eq("french")
-      expect(language.file_share_folder).to eq("languages/french")
+      expect(language.file_storage_prefix).to eq("FR_")
     end
   end
 end

--- a/spec/requests/languages/update_spec.rb
+++ b/spec/requests/languages/update_spec.rb
@@ -8,7 +8,7 @@ describe "Languages", type: :request do
 
     it "updates a Language" do
       language = create(:language)
-      language_params = { name: "french", file_share_folder: "languages/french" }
+      language_params = { name: "french" }
 
       put language_url(language), params: { language: language_params }
 


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #71 

### What Changed? And Why Did It Change?
- Removes the file_share_folder column from languages
- Add the method file_storage_prefix to the Language model

### How Has This Been Tested?
- Factory was updated
- Unit tests for the Language model are in place

### Please Provide Screenshots

### Additional Comments
