### PR TITLE
Make file_storage_prefix method case-insensitive

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -2,7 +2,7 @@ class Language < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   def file_storage_prefix
-    return "" if name == "English" || name.nil?
+    return "" if name.downcase == "english" || name.nil?
 
     "#{name.first(2).upcase}_"
   end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,5 +1,5 @@
 class Language < ApplicationRecord
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true, length: { minimum: 2 }
 
   def file_storage_prefix
     return "" if name.downcase == "english" || name.nil?

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Language, type: :model do
   context "validations" do
     let(:name) { Faker::Name.name }
     it { should validate_presence_of(:name) }
+    it { should validate_length_of(:name).is_at_least(2) }
   end
 
   describe ".file_storage_prefix" do

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -9,19 +9,35 @@ RSpec.describe Language, type: :model do
   end
 
   describe ".file_storage_prefix" do
-    context "when storage_prefix is English" do
+    context "when name is english" do
       let(:name) { "English" }
 
       it "returns an empty string" do
         expect(subject.file_storage_prefix).to eq("")
       end
+
+      context "when name is in the wrong case" do
+        let(:name) { "EnGliSh" }
+
+        it "returns an empty string" do
+          expect(subject.file_storage_prefix).to eq("")
+        end
+      end
     end
 
-    context "when storage_prefix is different than English" do
+    context "when name is different than English" do
       let(:name) { "French" }
 
       it "returns a string with the first two characters of the name, capitalized, followed by an underscore" do
         expect(subject.file_storage_prefix).to eq("FR_")
+      end
+
+      context "when name is in the wrong case" do
+        let(:name) { "frENCh" }
+
+        it "returns an empty string" do
+          expect(subject.file_storage_prefix).to eq("FR_")
+        end
       end
     end
   end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #71 

### What Changed? And Why Did It Change?
- Method was improved and now is case insensitive
- Test were added

### How Has This Been Tested?
- Unit tests for the Language model

### Please Provide Screenshots
#### Before
![Screen Shot 2025-02-22 at 14 53 58](https://github.com/user-attachments/assets/c2359944-3e20-442a-a1ea-bcad3df834db)
#### After
![Screen Shot 2025-02-22 at 14 55 44](https://github.com/user-attachments/assets/30ce5c1c-6774-4133-bedf-ec8d64dd4a27)

### Additional Comments
