### PR TITLE
Set current provider 75

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@ class ApplicationController < ActionController::Base
   include Authentication
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  def current_provider
+    @current_provider ||= begin
+      Current.user.providers.find(cookies.signed[:current_provider_id])
+    rescue ActiveRecord::RecordNotFound
+      Current.user.providers.first
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,5 @@ class ApplicationController < ActionController::Base
       Current.user.providers.first
     end
   end
+  helper_method :current_provider
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,11 +1,15 @@
 class SettingsController < ApplicationController
   def provider
-    provider = provider_scope.find(params[:id])
+    provider = provider_scope.find(provider_params[:id])
     cookies.signed[:current_provider_id] = provider.id if provider
     redirect_to request.referer || root_path
   end
 
   private
+
+  def provider_params
+    params.expect(provider: :id)
+  end
 
   def provider_scope
     @provider_scope ||= if Current.user.is_admin?

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,17 @@
+class SettingsController < ApplicationController
+  def provider
+    provider = provider_scope.find(params[:id])
+    cookies.signed[:current_provider_id] = provider.id if provider
+    redirect_to request.referer || root_path
+  end
+
+  private
+
+  def provider_scope
+    @provider_scope ||= if Current.user.is_admin?
+      Provider.all
+    else
+      Current.user.providers
+    end
+  end
+end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,6 +1,6 @@
 class SettingsController < ApplicationController
   def provider
-    provider = provider_scope.find(provider_params[:id])
+    provider = provider_scope.find_by(id: provider_params[:id])
     cookies.signed[:current_provider_id] = provider.id if provider
     redirect_to request.referer || root_path
   end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,6 +1,6 @@
 class SettingsController < ApplicationController
   def provider
-    provider = provider_scope.find_by(id: provider_params[:id])
+    provider = provider_scope.find(provider_params[:id])
     cookies.signed[:current_provider_id] = provider.id if provider
     redirect_to request.referer || root_path
   end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -46,7 +46,7 @@ class TopicsController < ApplicationController
   private
 
   def other_available_providers
-    return unless Current.user.providers.any?
+    return [] unless Current.user.providers.any?
 
     Current.user.providers.where.not(id: current_provider.id)
   end
@@ -69,8 +69,15 @@ class TopicsController < ApplicationController
   def scope
     @scope ||= if Current.user.is_admin?
       Topic.all
-    else
+    elsif current_provider.present?
       current_provider.topics
+    else
+      Current.user.topics
     end.includes(:language, :provider)
   end
+
+  def topics_title
+    current_provider.present? ? "#{current_provider.name}/topics" : "Topics"
+  end
+  helper_method :topics_title
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -70,7 +70,7 @@ class TopicsController < ApplicationController
     @scope ||= if Current.user.is_admin?
       Topic.all
     else
-      Current.user.topics
+      current_provider.topics
     end.includes(:language, :provider)
   end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -3,7 +3,7 @@ class TopicsController < ApplicationController
 
   def index
     @topics = scope.search_with_params(search_params)
-    @providers = scope.map(&:provider).uniq.sort_by(&:name)
+    @available_providers = other_available_providers
     @languages = scope.map(&:language).uniq.sort_by(&:name)
   end
 
@@ -45,16 +45,22 @@ class TopicsController < ApplicationController
 
   private
 
+  def other_available_providers
+    return unless Current.user.providers.any?
+
+    Current.user.providers.where.not(id: current_provider.id)
+  end
+
   def topic_params
     params.require(:topic).permit(:title, :description, :uid, :language_id, :provider_id, documents: [])
   end
 
-  helper_method :search_params
   def search_params
     return {} unless params[:search].present?
 
     params.require(:search).permit(:query, :state, :provider_id, :language_id, :year, :month, :order)
   end
+  helper_method :search_params
 
   def set_topic
     @topic = Topic.find(params[:id])

--- a/app/javascript/controllers/topics_controller.js
+++ b/app/javascript/controllers/topics_controller.js
@@ -2,14 +2,18 @@ import { Controller } from "@hotwired/stimulus"
 import { useDebounce } from "stimulus-use"
 
 export default class extends Controller {
-  static targets = [ "form" ]
+  static targets = [ "searchForm", "chooseForm" ]
   static debounces = [ "search" ]
 
   connect() {
     useDebounce(this, { wait: 300 })
   }
 
-  search() {
-    this.formTarget.requestSubmit()
+  searchTopics() {
+    this.searchFormTarget.requestSubmit()
+  }
+
+  chooseProvider() {
+    this.chooseFormTarget.requestSubmit()
   }
 }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -18,6 +18,7 @@ class Provider < ApplicationRecord
   has_many :regions, through: :branches
   has_many :contributors
   has_many :users, through: :contributors
+  has_many :topics
 
   validates :name, :provider_type, presence: true
   validates :name, uniqueness: true

--- a/app/views/topics/_choose_provider.html.erb
+++ b/app/views/topics/_choose_provider.html.erb
@@ -1,0 +1,12 @@
+<%= form_for :provider , url: provider_settings_path, method: :put, data: { controller: "topics", topics_target: "chooseForm" } do |f| %>
+  <div class="form-body">
+    <div class="row">
+      <div class="col-md-6 col-12">
+        <div class="form-group">
+          <%= f.label :provider %>
+          <%= f.select :id, options_from_collection_for_select(providers, :id, :name), { prompt: "Change provider" }, class: "form-select", data: { action: "change->topics#chooseProvider" } %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/topics/_choose_provider.html.erb
+++ b/app/views/topics/_choose_provider.html.erb
@@ -1,4 +1,4 @@
-<%= form_for :provider , url: provider_settings_path, method: :put, data: { controller: "topics", topics_target: "chooseForm" } do |f| %>
+<%= form_for :provider , url: provider_settings_path, method: :put, data: { controller: "topics", topics_target: "chooseForm", turbo_frame: "topics", turbo_action: "advance" } do |f| %>
   <div class="form-body">
     <div class="row">
       <div class="col-md-6 col-12">

--- a/app/views/topics/_search.html.erb
+++ b/app/views/topics/_search.html.erb
@@ -4,49 +4,43 @@
   </div>
   <div class="card-content">
     <div class="card-body">
-      <%= form_for :search, url: topics_path, method: :get, data: { controller: "topics", topics_target: "form", turbo_frame: "topic-list", turbo_action: "advance" } do |f| %>
+      <%= form_for :search, url: topics_path, method: :get, data: { controller: "topics", topics_target: "searchForm", turbo_frame: "topic-list", turbo_action: "advance" } do |f| %>
         <div class="form-body">
           <div class="row">
-            <div class="col-md-6 col-12">
+            <div class="col-12">
               <div class="form-group">
-                <%= f.label :provider %>
-                <%= f.select :provider_id, options_from_collection_for_select(providers, :id, :name, params[:provider_id]), { prompt: "Select provider" }, class: "form-select", data: { action: "change->topics#search" } %>
+                <%= f.label :query %>
+                <%= f.text_field :query, value: params[:query], class: "form-control", data: { action: "input->topics#searchTopics" } %>
               </div>
             </div>
             <div class="col-md-6 col-12">
               <div class="form-group">
                 <%= f.label :language %>
-                <%= f.select :language_id, options_from_collection_for_select(languages, :id, :name, params[:provider_id]),  { prompt: "Select language" }, class: "form-select", data: { action: "change->topics#search" } %>
-              </div>
-            </div>
-            <div class="col-md-6 col-12">
-              <div class="form-group">
-                <%= f.label :query %>
-                <%= f.text_field :query, value: params[:query], class: "form-control", data: { action: "input->topics#search" } %>
+                <%= f.select :language_id, options_from_collection_for_select(languages, :id, :name, params[:provider_id]),  { prompt: "Select language" }, class: "form-select", data: { action: "change->topics#searchTopics" } %>
               </div>
             </div>
             <div class="col-md-3 col-12">
               <div class="form-group">
                 <%= f.label :year %>
-                <%= f.select :year, options_for_select((Date.today.year-10..Date.today.year).to_a, params[:year]), { prompt: "Select year" }, class: "form-select", data: { action: "change->topics#search" } %>
+                <%= f.select :year, options_for_select((Date.today.year-10..Date.today.year).to_a, params[:year]), { prompt: "Select year" }, class: "form-select", data: { action: "change->topics#searchTopics" } %>
               </div>
             </div>
             <div class="col-md-3 col-12">
               <div class="form-group">
                 <%= f.label :month %>
-                <%= f.select :month, options_for_select((1..12).to_a, params[:month]), { prompt: "Select month" }, class: "form-select", data: { action: "change->topics#search" } %>
+                <%= f.select :month, options_for_select((1..12).to_a, params[:month]), { prompt: "Select month" }, class: "form-select", data: { action: "change->topics#searchTopics" } %>
               </div>
             </div>
             <div class="col-md-6 col-12">
               <div class="form-group">
                 <%= f.label :state %>
-                <%= f.select :state, options_for_select(Topic::STATES.index_with(&:itself), params[:state]), { prompt: "Select state" }, class: "form-select", data: { action: "change->topics#search" } %>
+                <%= f.select :state, options_for_select(Topic::STATES.index_with(&:itself), params[:state]), { prompt: "Select state" }, class: "form-select", data: { action: "change->topics#searchTopics" } %>
               </div>
             </div>
             <div class="col-md-6 col-12">
               <div class="form-group">
                 <%= f.label :order %>
-                <%= f.select :order, options_for_select(Topic::SORTS.reverse.index_with(&:itself), params[:order]), {}, class: "form-select", data: { action: "change->topics#search" } %>
+                <%= f.select :order, options_for_select(Topic::SORTS.reverse.index_with(&:itself), params[:order]), {}, class: "form-select", data: { action: "change->topics#searchTopics" } %>
               </div>
             </div>
             <div class="col-12 d-flex justify-content-end">

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -7,7 +7,7 @@
       <%= turbo_frame_tag "topics" do %>
         <div class="card">
           <div class="card-header d-flex justify-content-between align-items-center">
-            <h2 class="card-title"><%= current_provider.name %>'s topics</h2>
+            <h2 class="card-title"><%= topics_title %></h2>
             <%= link_to new_topic_path, class: "btn btn-primary" do %>
               <i class="bi bi-plus"></i> Add New Topic
             <% end %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -4,40 +4,42 @@
   <div class="row" id="table-striped">
     <div class="col-12 cold-md-12">
       <%= render "search", providers: @providers, languages: @languages, params: search_params  %>
-      <div class="card">
-        <div class="card-header d-flex justify-content-between align-items-center">
-          <h2 class="card-title"><%= current_provider.name %>'s topics</h2>
-          <%= link_to new_topic_path, class: "btn btn-primary" do %>
-            <i class="bi bi-plus"></i> Add New Topic
-          <% end %>
-        </div>
-        <div class="card-content">
-          <div class="card-body">
-            <% if @available_providers.any? %>
-              <%= render "choose_provider", providers: @available_providers %>
-            <% end %>
-            <p class="card-text"> Some important information or instruction can be placed here.</p>
-            <%= turbo_frame_tag "topic-list" do %>
-              <div class="table-responsive">
-                <table class="table table-lg table-striped mb-0">
-                  <thead>
-                    <tr>
-                      <th>Title</th>
-                      <th>Description</th>
-                      <th>UID</th>
-                      <th>Language</th>
-                      <th>Provider</th>
-                      <th>State</th>
-                      <th class="text-end">Actions</th>
-                    </tr>
-                  </thead>
-                  <%= render "list", topics: @topics %>
-                </table>
-              </div>
+      <%= turbo_frame_tag "topics" do %>
+        <div class="card">
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <h2 class="card-title"><%= current_provider.name %>'s topics</h2>
+            <%= link_to new_topic_path, class: "btn btn-primary" do %>
+              <i class="bi bi-plus"></i> Add New Topic
             <% end %>
           </div>
+          <div class="card-content">
+            <div class="card-body">
+              <% if @available_providers.any? %>
+                <%= render "choose_provider", providers: @available_providers %>
+              <% end %>
+              <p class="card-text"> Some important information or instruction can be placed here.</p>
+              <%= turbo_frame_tag "topic-list" do %>
+                <div class="table-responsive">
+                  <table class="table table-lg table-striped mb-0">
+                    <thead>
+                      <tr>
+                        <th>Title</th>
+                        <th>Description</th>
+                        <th>UID</th>
+                        <th>Language</th>
+                        <th>Provider</th>
+                        <th>State</th>
+                        <th class="text-end">Actions</th>
+                      </tr>
+                    </thead>
+                    <%= render "list", topics: @topics %>
+                  </table>
+                </div>
+              <% end %>
+            </div>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </section>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -6,13 +6,16 @@
       <%= render "search", providers: @providers, languages: @languages, params: search_params  %>
       <div class="card">
         <div class="card-header d-flex justify-content-between align-items-center">
-          <h2 class="card-title">Topics</h2>
+          <h2 class="card-title"><%= current_provider.name %>'s topics</h2>
           <%= link_to new_topic_path, class: "btn btn-primary" do %>
             <i class="bi bi-plus"></i> Add New Topic
           <% end %>
         </div>
         <div class="card-content">
           <div class="card-body">
+            <% if @available_providers.any? %>
+              <%= render "choose_provider", providers: @available_providers %>
+            <% end %>
             <p class="card-text"> Some important information or instruction can be placed here.</p>
             <%= turbo_frame_tag "topic-list" do %>
               <div class="table-responsive">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
   resources :topics do
     put :archive, on: :member
   end
+  resource :settings, only: [] do
+    put :provider, on: :collection
+  end
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest

--- a/spec/requests/settings/provider_spec.rb
+++ b/spec/requests/settings/provider_spec.rb
@@ -9,7 +9,7 @@ describe "Settings", type: :request do
 
     context "when provider cannot be found" do
       it "does not update current provider" do
-        put provider_settings_url, params: { id: provider.id }
+        put provider_settings_url, params: { provider: { id: provider.id } }
 
         expect(response).to have_http_status(:not_found)
       end
@@ -21,7 +21,7 @@ describe "Settings", type: :request do
       end
 
       it "updates current provider" do
-        put provider_settings_url, params: { id: provider.id }
+        put provider_settings_url, params: { provider: { id: provider.id } }
 
         signed_cookies = ActionDispatch::Request.new(Rails.application.env_config).cookie_jar
 

--- a/spec/requests/settings/provider_spec.rb
+++ b/spec/requests/settings/provider_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe "Settings", type: :request do
+  describe "PUT /settings/provider" do
+    let(:user) { create(:user) }
+    let(:provider) { create(:provider) }
+
+    before { sign_in(user) }
+
+    context "when provider cannot be found" do
+      it "does not update current provider" do
+        put provider_settings_url, params: { id: provider.id }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when user has access to provider" do
+      before do
+        user.providers << provider
+      end
+
+      it "updates current provider" do
+        put provider_settings_url, params: { id: provider.id }
+
+        signed_cookies = ActionDispatch::Request.new(Rails.application.env_config).cookie_jar
+
+        expect(response).to redirect_to(root_url)
+        expect(signed_cookies.signed[:current_provider_id]).to eq(provider.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

This PR covers sub-issue from the issue about [provider-based filtering](https://github.com/rubyforgood/skillrx/issues/75)
Here we suppose that user will spend more time working with one provider, thus it is better to have current provider in session and not in url.
If this will work, next PR will close the issue #75 

### What Changed? And Why Did It Change?

* add settings controller
* add option to switch current provider using new controller
* add new stimulus action and turbo frame to make current provider update seamless (no page reload)
* scope topics for non-admin user to current provider

### How Has This Been Tested?

Added request specs for new controller

### Please Provide Screenshots

<img width="1119" alt="Screenshot 2025-02-27 at 22 56 18" src="https://github.com/user-attachments/assets/298a457d-670f-42f6-99f0-b522809f2bae" />

### Additional Comments

I think that there could be a better place for provider selector. We can move it later
