### PR TITLE
use current_provider for topic when user is not an admin

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,1 @@
+web: bin/rails server -p 3000

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -52,7 +52,14 @@ class TopicsController < ApplicationController
   end
 
   def topic_params
-    params.require(:topic).permit(:title, :description, :uid, :language_id, :provider_id, documents: [])
+    params
+      .require(:topic)
+      .permit(:title, :description, :uid, :language_id, :provider_id, documents: []).tap do |perm_params|
+        if perm_params["provider_id"].present?
+          perm_params["provider_id"] = Current.user.providers.find(perm_params["provider_id"]).id
+          perm_params["provider_id"] = current_provider.id if current_provider && !Current.user.is_admin?
+        end
+      end
   end
 
   def search_params

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -16,10 +16,12 @@
           <%= f.label :language %>
           <%= f.collection_select :language_id, Language.all, :id, :name, { prompt: "Select Language" }, class: "form-select" %>
         </div>
-        <div class="form-group">
-          <%= f.label :provider %>
-          <%= f.collection_select :provider_id, Provider.all, :id, :name, { prompt: "Select Provider" }, class: "form-select" %>
-        </div>
+        <% if Current.user.is_admin? %>
+          <div class="form-group">
+            <%= f.label :provider %>
+            <%= f.collection_select :provider_id, Provider.all, :id, :name, { prompt: "Select Provider" }, class: "form-select" %>
+          </div>
+        <% end %>
         <div class="form-group">
           <%= f.label :description %>
           <%= f.text_area :description, class: "form-control", placeholder: "Descripion" %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -8,7 +8,7 @@
         <div class="card">
           <div class="card-header d-flex justify-content-between align-items-center">
             <h2 class="card-title"><%= topics_title %></h2>
-            <%= link_to new_topic_path, class: "btn btn-primary" do %>
+            <%= link_to new_topic_path, class: "btn btn-primary", data: { turbo: false } do %>
               <i class="bi bi-plus"></i> Add New Topic
             <% end %>
           </div>

--- a/bin/server
+++ b/bin/server
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-overmind start -r all
+overmind start -r all -f Procfile.dev

--- a/spec/requests/topics/create_spec.rb
+++ b/spec/requests/topics/create_spec.rb
@@ -7,7 +7,10 @@ describe "Topics", type: :request do
     let(:language) { create(:language) }
     let(:topic_params) { attributes_for(:topic, provider_id: provider.id, language_id: language.id) }
 
-    before { sign_in(user) }
+    before do
+      provider.users << user
+      sign_in(user)
+    end
 
     it "creates a Topic" do
       post topics_url, params: { topic: topic_params }
@@ -17,6 +20,36 @@ describe "Topics", type: :request do
       expect(topic.title).to eq("topic")
       expect(topic.description).to eq("details")
       expect(topic.state).to eq("active")
+    end
+
+    context "when current provider is set" do
+      let(:current_provider) { create(:provider) }
+
+      before do
+        current_provider.users << user
+        cookies = ActionDispatch::Request.new(Rails.application.env_config).cookie_jar
+        cookies.signed[:current_provider_id] = current_provider.id
+      end
+
+      it "creates a Topic for the current provider" do
+        post topics_url, params: { topic: topic_params }
+
+        expect(response).to redirect_to(topics_url)
+        topic = Topic.last
+        expect(topic.provider).to eq(current_provider)
+      end
+
+      context "when user is an admin" do
+        before { user.update(is_admin: true) }
+
+        it "creates a Topic for the selected provider" do
+          post topics_url, params: { topic: topic_params }
+
+          expect(response).to redirect_to(topics_url)
+          topic = Topic.last
+          expect(topic.provider).to eq(provider)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

This PR covers final items from [the latest issue about topics](https://github.com/rubyforgood/skillrx/issues/75)

### What Changed? And Why Did It Change?

* when creating a topic use current provider by default for non-admin users and hide select box
* when creating a topic make sure that user has access to passed provider
* make "Add new topic" button work without Turbo

### How Has This Been Tested?

Added some new request specs

### Please Provide Screenshots

<img width="585" alt="Screenshot 2025-03-06 at 23 17 47" src="https://github.com/user-attachments/assets/2f562d65-39aa-464d-9b9c-b6a3a140d927" />

### Additional Comments

New Profile breaks dev env. For example, we don't have solid queue setup and don't have background jobs yet.
Since it is needed for Heroku, I've added new Procfile for dev env and switched bin script to this new file.