### PR TITLE
Topic action buttons fixed

### DIFF
--- a/app/views/topics/_list.html.erb
+++ b/app/views/topics/_list.html.erb
@@ -8,19 +8,19 @@
       <td class="text-bold-500"><%= topic.provider.name %></td>
       <td class="text-bold-500"><%= topic.state %></td>
       <td class="text-end">
-        <%= link_to topic, class: "btn btn-primary btn-sm" do %>
+        <%= link_to topic, class: "btn btn-primary btn-sm", data: {turbo: false } do %>
           <i class="bi bi-search"></i> View
         <% end %>
-        <%= link_to edit_topic_path(topic), class: "btn btn-secondary btn-sm" do %>
+        <%= link_to edit_topic_path(topic), class: "btn btn-secondary btn-sm", data: {turbo: false } do %>
           <i class="bi bi-pencil"></i> Edit
         <% end %>
         <% unless topic.archived? %>
-          <%= link_to archive_topic_path(topic), method: :put, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm" do %>
+          <%= link_to archive_topic_path(topic), method: :put, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm", data: {turbo: false } do %>
             <i class="bi bi-archive"></i> Archive
           <% end %>
         <% end %>
         <% if Current.user.is_admin? %>
-          <%= link_to topic, method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm" do %>
+          <%= link_to topic, method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm", data: {turbo: false } do %>
             <i class="bi bi-trash"></i> Delete
           <% end %>
         <% end %>

--- a/app/views/topics/_list.html.erb
+++ b/app/views/topics/_list.html.erb
@@ -14,16 +14,6 @@
         <%= link_to edit_topic_path(topic), class: "btn btn-secondary btn-sm", data: {turbo: false } do %>
           <i class="bi bi-pencil"></i> Edit
         <% end %>
-        <% unless topic.archived? %>
-          <%= link_to archive_topic_path(topic), method: :put, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm", data: {turbo: false } do %>
-            <i class="bi bi-archive"></i> Archive
-          <% end %>
-        <% end %>
-        <% if Current.user.is_admin? %>
-          <%= link_to topic, method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm", data: {turbo: false } do %>
-            <i class="bi bi-trash"></i> Delete
-          <% end %>
-        <% end %>
       </td>
     </tr>
   <% end %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -8,7 +8,7 @@
         <div class="card">
           <div class="card-header d-flex justify-content-between align-items-center">
             <h2 class="card-title"><%= topics_title %></h2>
-            <%= link_to new_topic_path, class: "btn btn-primary" do %>
+            <%= link_to new_topic_path, class: "btn btn-primary", data: {turbo: false } do %>
               <i class="bi bi-plus"></i> Add New Topic
             <% end %>
           </div>


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #92 

### What Changed? And Why Did It Change?
Turned off turbo frames for the action buttons and "add new topic" button.
### How Has This Been Tested?

### Please Provide Screenshots
<img width="804" alt="Screenshot 2025-03-06 at 6 39 23 PM" src="https://github.com/user-attachments/assets/a983e018-6096-4761-be5f-8c718545b979" />
<img width="825" alt="Screenshot 2025-03-06 at 6 39 55 PM" src="https://github.com/user-attachments/assets/168ca234-7d99-4f1f-a166-660a87db4f3f" />

### Additional Comments
