### PR TITLE
reuse provider scope for topics controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,11 +3,19 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  def provider_scope
+    @provider_scope ||= if Current.user.is_admin?
+      Provider.all
+    else
+      Current.user.providers
+    end
+  end
+
   def current_provider
     @current_provider ||= begin
-      Current.user.providers.find(cookies.signed[:current_provider_id])
+      provider_scope.find(cookies.signed[:current_provider_id])
     rescue ActiveRecord::RecordNotFound
-      Current.user.providers.first
+      provider_scope.first
     end
   end
   helper_method :current_provider

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -10,12 +10,4 @@ class SettingsController < ApplicationController
   def provider_params
     params.expect(provider: :id)
   end
-
-  def provider_scope
-    @provider_scope ||= if Current.user.is_admin?
-      Provider.all
-    else
-      Current.user.providers
-    end
-  end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -46,9 +46,9 @@ class TopicsController < ApplicationController
   private
 
   def other_available_providers
-    return [] unless Current.user.providers.any?
+    return [] unless provider_scope.any?
 
-    Current.user.providers.where.not(id: current_provider.id)
+    provider_scope.where.not(id: current_provider.id)
   end
 
   def topic_params
@@ -56,7 +56,7 @@ class TopicsController < ApplicationController
       .require(:topic)
       .permit(:title, :description, :uid, :language_id, :provider_id, documents: []).tap do |perm_params|
         if perm_params["provider_id"].present?
-          perm_params["provider_id"] = Current.user.providers.find(perm_params["provider_id"]).id
+          perm_params["provider_id"] = provider_scope.find(perm_params["provider_id"]).id
           perm_params["provider_id"] = current_provider.id if current_provider && !Current.user.is_admin?
         end
       end

--- a/spec/requests/topics/create_spec.rb
+++ b/spec/requests/topics/create_spec.rb
@@ -22,6 +22,20 @@ describe "Topics", type: :request do
       expect(topic.state).to eq("active")
     end
 
+    context "when user is ad admin" do
+      let(:new_provider) { create(:provider) }
+
+      before { user.update(is_admin: true) }
+
+      it "creates a Topic" do
+        post topics_url, params: { topic: topic_params.merge(provider_id: new_provider.id) }
+
+        expect(response).to redirect_to(topics_url)
+        topic = Topic.last
+        expect(topic.provider_id).to eq(new_provider.id)
+      end
+    end
+
     context "when current provider is set" do
       let(:current_provider) { create(:provider) }
 


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

This fixes a bug when admin user is trying to create a topic while not having any topic connected to this user in DB

### What Changed? And Why Did It Change?

Reusing provider scope from settings controller

### How Has This Been Tested?

Added separate test scenario for admin user