### PR TITLE
Alter production db config to match heroku defaults

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -80,15 +80,16 @@ test:
 production:
   primary:
     <<: *default
-    url: <%= ENV['DATABASE_URL'] %>
+    database: skillrx_production
   cache:
     <<: *default
+    database: sklillrx_production_cache
     migrations_paths: db/cache_migrate
   queue:
     <<: *default
-    url: <%= ENV['HEROKU_POSTGRESQL_QUEUE_URL'] || ENV['DATABASE_URL'] %>
+    database: skillrx_production_queue
     migrations_paths: db/queue_migrate
   cable:
     <<: *default
-    url: <%= ENV['HEROKU_POSTGRESQL_CABLE_URL'] || ENV['DATABASE_URL'] %>
+    database: skillrx_production_cable
     migrations_paths: db/cable_migrate


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Alter database configuration to match Heroku's recommended defaults so that migrations will run properly.