### PR TITLE
Fix topics filtering by provider

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
     @current_provider ||= begin
       provider_scope.find(cookies.signed[:current_provider_id])
     rescue ActiveRecord::RecordNotFound
-      provider_scope.first
+      provider_scope.first || NullProvider.new
     end
   end
   helper_method :current_provider

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -89,7 +89,7 @@ class TopicsController < ApplicationController
   end
 
   def scope
-    @scope ||= current_provider&.topics&.includes(:language) ||  Topic.none
+    @scope ||= current_provider.topics.includes(:language)
   end
 
   def topic_tags_params

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -89,13 +89,7 @@ class TopicsController < ApplicationController
   end
 
   def scope
-    @scope ||= if Current.user.is_admin?
-      Topic.includes(:provider).all
-    elsif current_provider.present?
-      current_provider.topics
-    else
-      Current.user.topics
-    end.includes(:language)
+    @scope ||= current_provider&.topics&.includes(:language) ||  Topic.none
   end
 
   def topic_tags_params
@@ -105,7 +99,7 @@ class TopicsController < ApplicationController
   def search_params
     return {} unless params[:search].present?
 
-    params.require(:search).permit(:query, :state, :provider_id, :language_id, :year, :month, :order, tag_list: [])
+    params.require(:search).permit(:query, :state, :language_id, :year, :month, :order, tag_list: [])
   end
   helper_method :search_params
 

--- a/app/models/concerns/searcheable.rb
+++ b/app/models/concerns/searcheable.rb
@@ -16,10 +16,6 @@ module Searcheable
       where("extract(month from created_at) = ?", month)
     end
 
-    def by_provider(provider_id)
-      where(provider_id: provider_id)
-    end
-
     def by_language(language_id)
       where(language_id: language_id)
     end
@@ -43,7 +39,6 @@ module Searcheable
     scope :search_with_params, ->(params) do
       self
         .then { |scope| params[:state].present? ? scope.by_state(params[:state]) : scope }
-        .then { |scope| params[:provider_id].present? ? scope.by_provider(params[:provider_id]) : scope }
         .then { |scope| params[:language_id].present? ? scope.by_language(params[:language_id]): scope }
         .then { |scope| params[:year].present? ? scope.by_year(params[:year]) : scope }
         .then { |scope| params[:month].present? ? scope.by_month(params[:month]) : scope }

--- a/app/models/null_provider.rb
+++ b/app/models/null_provider.rb
@@ -1,0 +1,5 @@
+class NullProvider
+  def topics = Topic.none
+
+  def present? = false
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,8 +30,4 @@ class User < ApplicationRecord
       .then { |scope| params[:is_admin].present? ? scope.where(is_admin: params[:is_admin]) : scope }
       .then { |scope| scope.order(created_at: params[:order]&.to_sym || :desc) }
   end
-
-  def topics
-    Topic.where(provider_id: providers.pluck(:id))
-  end
 end

--- a/spec/system/topic_search_spec.rb
+++ b/spec/system/topic_search_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "Topics search", type: :system do
-  let(:admin) { create(:user, :admin, email: "admin@mail.com") }
   let(:english) { create(:language, name: "English") }
   let(:spanish) { create(:language, name: "Spanish") }
   let(:tag_name) { create(:language, name: "Basic") }
+  let(:provider_1) { create(:provider) }
+  let(:provider_2) { create(:provider) }
   let!(:spanish_active_topic) do
     create(
       :topic,
@@ -12,6 +13,7 @@ RSpec.describe "Topics search", type: :system do
       title: "Tratamiento del resfriado",
       created_at: Date.new(2025, 02, 03),
       published_at: Date.new(2025, 02, 03),
+      provider: provider_1
     )
   end
   let!(:english_active_topic) do
@@ -22,15 +24,26 @@ RSpec.describe "Topics search", type: :system do
       description: "All the latest information about nasopharyngitis",
       created_at: Date.new(2025, 03, 04),
       published_at: Date.new(2025, 03, 04),
+      provider: provider_1
     )
   end
   let!(:english_archived_topic) do
     create(
-      :topic, :archived,
+      :topic,
+      :archived,
       language: english,
       title: "Obsolete",
       created_at: Date.new(2023, 02, 01),
       published_at: Date.new(2023, 02, 01),
+      provider: provider_1
+    )
+  end
+  let!(:other_provider_topic) do
+    create(
+      :topic,
+      language: english,
+      title: "Other provider topic",
+      provider: provider_2
     )
   end
 
@@ -41,114 +54,288 @@ RSpec.describe "Topics search", type: :system do
   end
 
   before do
-    login_as(admin)
-    click_link("Topics")
+    login_as(user)
   end
 
-  it "shows all topics" do
-    expect(page).to have_text(english_active_topic.title)
-    expect(page).to have_text(spanish_active_topic.title)
-    expect(page).to have_text(english_archived_topic.title)
-  end
+  context "when the user is an admin" do
+    let(:user) { create(:user, :admin, email: "admin@mail.com") }
 
-  context "when searching by title" do
-    it "only displays topics matching the search" do
-      fill_in "search_query", with: "tratamiento"
+    before { click_link("Topics") }
 
-      expect(page).to have_text(spanish_active_topic.title)
-      expect(page).not_to have_text(english_active_topic.title)
-      expect(page).not_to have_text(english_archived_topic.title)
-    end
-  end
-
-  context "when searching by description" do
-    it "only displays topics matching the search" do
-      fill_in "search_query", with: "pharyn"
-
+    it "shows all topics from first provider" do
       expect(page).to have_text(english_active_topic.title)
-      expect(page).not_to have_text(spanish_active_topic.title)
-      expect(page).not_to have_text(english_archived_topic.title)
-    end
-  end
-
-  context "when searching by language" do
-    it "only displays topics matching the search" do
-      select "Spanish", from: "search_language_id"
-
-      expect(page).to have_text(spanish_active_topic.title)
-      expect(page).not_to have_text(english_active_topic.title)
-      expect(page).not_to have_text(english_archived_topic.title)
-
-      select "English", from: "search_language_id"
-
-      expect(page).to have_text(english_active_topic.title)
-      expect(page).to have_text(english_archived_topic.title)
-      expect(page).not_to have_text(spanish_active_topic.title)
-    end
-  end
-
-  context "when searching by year" do
-    it "only displays topics matching the search" do
-      select "2025", from: "search_year"
-
-      expect(page).to have_text(spanish_active_topic.title)
-      expect(page).to have_text(english_active_topic.title)
-      expect(page).not_to have_text(english_archived_topic.title)
-
-      select "2023", from: "search_year"
-
-      expect(page).to have_text(english_archived_topic.title)
-      expect(page).not_to have_text(spanish_active_topic.title)
-      expect(page).not_to have_text(english_active_topic.title)
-    end
-  end
-
-  context "when searching by month" do
-    it "only displays topics matching the search" do
-      select "2", from: "search_month"
-
       expect(page).to have_text(spanish_active_topic.title)
       expect(page).to have_text(english_archived_topic.title)
-      expect(page).not_to have_text(english_active_topic.title)
+    end
 
-      select "3", from: "search_month"
+    context "when searching by title" do
+      it "only displays topics matching the search" do
+        fill_in "search_query", with: "tratamiento"
 
-      expect(page).to have_text(english_active_topic.title)
-      expect(page).not_to have_text(english_archived_topic.title)
-      expect(page).not_to have_text(spanish_active_topic.title)
+        expect(page).to have_text(spanish_active_topic.title)
+        expect(page).not_to have_text(english_active_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
+      end
+    end
+
+    context "when searching by description" do
+      it "only displays topics matching the search" do
+        fill_in "search_query", with: "pharyn"
+
+        expect(page).to have_text(english_active_topic.title)
+        expect(page).not_to have_text(spanish_active_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
+      end
+    end
+
+    context "when searching by language" do
+      it "only displays topics matching the search" do
+        select "Spanish", from: "search_language_id"
+
+        expect(page).to have_text(spanish_active_topic.title)
+        expect(page).not_to have_text(english_active_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
+
+        select "English", from: "search_language_id"
+
+        expect(page).to have_text(english_active_topic.title)
+        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(spanish_active_topic.title)
+      end
+    end
+
+    context "when searching by year" do
+      it "only displays topics matching the search" do
+        select "2025", from: "search_year"
+
+        expect(page).to have_text(spanish_active_topic.title)
+        expect(page).to have_text(english_active_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
+
+        select "2023", from: "search_year"
+
+        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(spanish_active_topic.title)
+        expect(page).not_to have_text(english_active_topic.title)
+      end
+    end
+
+    context "when searching by month" do
+      it "only displays topics matching the search" do
+        select "2", from: "search_month"
+
+        expect(page).to have_text(spanish_active_topic.title)
+        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(english_active_topic.title)
+
+        select "3", from: "search_month"
+
+        expect(page).to have_text(english_active_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(spanish_active_topic.title)
+      end
+    end
+
+    context "when searching by state" do
+      it "only displays topics matching the search" do
+        select "active", from: "search_state"
+
+        expect(page).to have_text(spanish_active_topic.title)
+        expect(page).to have_text(english_active_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
+
+        select "archived", from: "search_state"
+
+        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(spanish_active_topic.title)
+        expect(page).not_to have_text(english_active_topic.title)
+      end
+    end
+
+    context "when searching by tags" do
+      it "only displays topics matching the search" do
+        choose_tag(tag_name)
+
+        expect(page).to have_text(english_topic_tagged.title)
+        expect(page).not_to have_text(spanish_active_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
+      end
+    end
+
+    context "when sorting" do
+      it "displays users in the selected order" do
+        select "asc", from: "search_order"
+        expect(page).to have_text(/#{english_archived_topic.title}.+#{spanish_active_topic.title}.+#{english_active_topic.title}/m)
+      end
+    end
+
+    context "when switching to another provider" do
+      it "only shows topics from the selected provider" do
+        select provider_2.name, from: "provider_id"
+        expect(page).to have_text(other_provider_topic.title)
+        expect(page).not_to have_text(english_active_topic.title)
+        expect(page).not_to have_text(spanish_active_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
+      end
     end
   end
 
-  context "when searching by state" do
-    it "only displays topics matching the search" do
-      select "active", from: "search_state"
+  context "when the user is a contributor" do
+    let(:user) { create(:user) }
 
-      expect(page).to have_text(spanish_active_topic.title)
-      expect(page).to have_text(english_active_topic.title)
-      expect(page).not_to have_text(english_archived_topic.title)
+    context "with no associated providers" do
+      before { click_link("Topics") }
 
-      select "archived", from: "search_state"
-
-      expect(page).to have_text(english_archived_topic.title)
-      expect(page).not_to have_text(spanish_active_topic.title)
-      expect(page).not_to have_text(english_active_topic.title)
+      it "shows no topics" do
+        expect(page).to have_link("Add New Topic")
+        expect(page).not_to have_text(english_active_topic.title)
+        expect(page).not_to have_text(spanish_active_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(other_provider_topic.title)
+      end
     end
-  end
 
-  context "when searching by tags" do
-    it "only displays topics matching the search" do
-      choose_tag(tag_name)
+    context "with 1 associated provider" do
+      before do
+        user.providers << provider_1
+        click_link("Topics")
+      end
 
-      expect(page).to have_text(english_topic_tagged.title)
-      expect(page).not_to have_text(spanish_active_topic.title)
-      expect(page).not_to have_text(english_archived_topic.title)
+      it "doesn't have a dropdown menu to change the provider" do
+        expect(page).not_to have_select("provider_id")
+      end
+
+      it "only shows topics from its first associated provider" do
+        expect(page).to have_text(english_active_topic.title)
+        expect(page).to have_text(spanish_active_topic.title)
+        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(other_provider_topic.title)
+      end
+
+      context "when searching by title" do
+        it "only displays topics matching the search" do
+          fill_in "search_query", with: "tratamiento"
+
+          expect(page).to have_text(spanish_active_topic.title)
+          expect(page).not_to have_text(english_active_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
+        end
+      end
+
+      context "when searching by description" do
+        it "only displays topics matching the search" do
+          fill_in "search_query", with: "pharyn"
+
+          expect(page).to have_text(english_active_topic.title)
+          expect(page).not_to have_text(spanish_active_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
+        end
+      end
+
+      context "when searching by language" do
+        it "only displays topics matching the search" do
+          select "Spanish", from: "search_language_id"
+
+          expect(page).to have_text(spanish_active_topic.title)
+          expect(page).not_to have_text(english_active_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
+
+          select "English", from: "search_language_id"
+
+          expect(page).to have_text(english_active_topic.title)
+          expect(page).to have_text(english_archived_topic.title)
+          expect(page).not_to have_text(spanish_active_topic.title)
+        end
+      end
+
+      context "when searching by year" do
+        it "only displays topics matching the search" do
+          select "2025", from: "search_year"
+
+          expect(page).to have_text(spanish_active_topic.title)
+          expect(page).to have_text(english_active_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
+
+          select "2023", from: "search_year"
+
+          expect(page).to have_text(english_archived_topic.title)
+          expect(page).not_to have_text(spanish_active_topic.title)
+          expect(page).not_to have_text(english_active_topic.title)
+        end
+      end
+
+      context "when searching by month" do
+        it "only displays topics matching the search" do
+          select "2", from: "search_month"
+
+          expect(page).to have_text(spanish_active_topic.title)
+          expect(page).to have_text(english_archived_topic.title)
+          expect(page).not_to have_text(english_active_topic.title)
+
+          select "3", from: "search_month"
+
+          expect(page).to have_text(english_active_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
+          expect(page).not_to have_text(spanish_active_topic.title)
+        end
+      end
+
+      context "when searching by state" do
+        it "only displays topics matching the search" do
+          select "active", from: "search_state"
+
+          expect(page).to have_text(spanish_active_topic.title)
+          expect(page).to have_text(english_active_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
+
+          select "archived", from: "search_state"
+
+          expect(page).to have_text(english_archived_topic.title)
+          expect(page).not_to have_text(spanish_active_topic.title)
+          expect(page).not_to have_text(english_active_topic.title)
+        end
+      end
+
+      context "when searching by tags" do
+        it "only displays topics matching the search" do
+          choose_tag(tag_name)
+
+          expect(page).to have_text(english_topic_tagged.title)
+          expect(page).not_to have_text(spanish_active_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
+        end
+      end
+
+      context "when sorting" do
+        it "displays users in the selected order" do
+          select "asc", from: "search_order"
+          expect(page).to have_text(/#{english_archived_topic.title}.+#{spanish_active_topic.title}.+#{english_active_topic.title}/m)
+        end
+      end
     end
-  end
 
-  context "when sorting" do
-    it "displays users in the selected order" do
-      select "asc", from: "search_order"
-      expect(page).to have_text(/#{english_archived_topic.title}.+#{spanish_active_topic.title}.+#{english_active_topic.title}/m)
+    context "with multiple associated providers" do
+      before do
+        user.providers << [ provider_1, provider_2 ]
+        click_link("Topics")
+      end
+
+      it "only shows topics from its first associated provider" do
+        expect(page).to have_text(english_active_topic.title)
+        expect(page).to have_text(spanish_active_topic.title)
+        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(other_provider_topic.title)
+      end
+
+      context "when switching to another provider" do
+        it "only shows topics from the selected provider" do
+          select provider_2.name, from: "provider_id"
+          expect(page).to have_text(other_provider_topic.title)
+          expect(page).not_to have_text(english_active_topic.title)
+          expect(page).not_to have_text(spanish_active_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
+        end
+      end
     end
   end
 end

--- a/spec/system/topic_search_spec.rb
+++ b/spec/system/topic_search_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Topics search", type: :system do
   let(:english) { create(:language, name: "English") }
   let(:spanish) { create(:language, name: "Spanish") }
-  let(:tag_name) { create(:language, name: "Basic") }
+  let(:tag_name) { create(:language, name: "Basic").name }
   let(:provider_1) { create(:provider) }
   let(:provider_2) { create(:provider) }
   let!(:spanish_active_topic) do


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #136 <!--fill issue number-->

### What Changed? And Why Did It Change?
It redefines the scope of Topics shown on the Topics page to ensure we only display Topics from the currently selected provider.
This fixes a bug that, for Admin users, caused all Topics to be displayed regardless of the Provider, even though the name of the first Provider's was displayed at the top and gave the impression that the Topics were already filtered by Provider.

### How Has This Been Tested?
With system tests (spec/system/topic_search_spec.rb) and by hand

### Please Provide Screenshots

https://github.com/user-attachments/assets/af78f44e-3f07-4a3f-836e-b53b1051019b

### Additional Comments
After making this change, I saw some tests were failing because they are set up in a way where users who are Contributors have no Providers. So I made it so that Contributors can still access the "Topics" page even if they don't have any Providers, in case that's something that may happen when we first add users, but that means they wouldn't be able to see any Topics or create new ones. We could display a message such as "You haven't been added to a provider yet" on the Topics page to clarify the situation, or we could redirect them to the dashboard if they don't have a provider. I wasn't sure what the desired behaviour was, please let me know and I can make the changes.