### PR TITLE
Import tags

### DIFF
--- a/lib/autorequire/data_import.rb
+++ b/lib/autorequire/data_import.rb
@@ -10,6 +10,7 @@ class DataImport
     Language.destroy_all
     Region.destroy_all
     User.destroy_all
+    Tag.destroy_all
   end
 
   def self.import_all
@@ -19,6 +20,7 @@ class DataImport
     # import_branches
     # import_contributors
     import_topics
+    import_tags
     restore_default_users
   end
 
@@ -106,6 +108,28 @@ class DataImport
       )
       puts "#{topic.title} #{topic.new_record? ? "created" : "already exists"}"
       topic.save!
+    end
+  end
+
+  def self.import_tags
+    tag_data = CSV.read(file_path("tags.csv"), headers: true)
+    tag_data.each do |row|
+      tag = Tag.find_or_initialize_by(id: row["Tag_ID"])
+      tag.assign_attributes(
+        name: row["Tag_Name"],
+        )
+
+          puts "#{tag.name} #{tag.new_record? ? "created" : "already exists"}"
+        tag.save!
+        # if tag.save
+        #   puts "#{tag.name} #{tag.new_record? ? "created" : "already exists"}"
+        # else
+        #   dup_tag = Tag.find_by(name: row["Tag_Name"])
+        #   if dup_tag
+        #     puts "Using existing tag #{dup_tag.name} (ID: #{dup_tag.id})"
+        #     tag.id = dup_tag.id if tag.new_record?
+        #   end
+        # end
     end
   end
 

--- a/lib/autorequire/data_import.rb
+++ b/lib/autorequire/data_import.rb
@@ -18,8 +18,6 @@ class DataImport
     import_regions
     import_providers
     import_languages
-    # import_branches
-    # import_contributors
     import_topics
     import_tags
     import_topic_tags
@@ -52,7 +50,7 @@ class DataImport
         provider.assign_attributes(
           name: row["Provider_Name"],
           provider_type: row["Provider_Type"],
-        )
+          )
         provider.save!
       end
       puts "#{provider.name} #{new_record ? "created" : "already exists"}"
@@ -107,7 +105,7 @@ class DataImport
         published_at: DateTime.new(created_year, created_month, 1),
         # uid: uid,
         state: row["Topic_Archived"].to_i,
-      )
+        )
       puts "#{topic.title} #{topic.new_record? ? "created" : "already exists"}"
       topic.save!
     end
@@ -115,41 +113,50 @@ class DataImport
 
   def self.import_tags
     data = CSV.read(file_path("tags.csv"), headers: true)
-
     data.each do |row|
       tag_id = row["Tag_ID"].to_i
-      tag_name = row["Tag_Name"]
-      language = row["tag_language"]
-
-      tag = ActsAsTaggableOn::Tag.find_or_initialize_by(id: tag_id)
+      tag_name = row["Tag_Name"]&.strip
 
       begin
-        tag.name = tag_name
-        tag.save!
+        Tag.find_or_create_by!(id: tag_id, name: tag_name)
       rescue ActiveRecord::RecordInvalid
-        tag.name = "#{tag_name}_#{language}"
-        tag.save!
+        puts "Tag #{tag_name} is invalid"
       end
     end
     puts "Tags import completed"
   end
 
   def self.import_topic_tags
-    data = CSV.read(file_path("topic_tags.csv"), headers: true)
+    tags_data = CSV.read(file_path("tags.csv"))
+    join_data = CSV.read(file_path("topic_tags.csv"))
 
-    data.each do |row|
-      topic_id = row["Topic_ID"].to_i
-      tag_id = row["Tag_ID"].to_i
-      next if topic_id.blank? || tag_id.blank?
+    # It returns a hash where the key is the Topic_ID and the value is an array of Tag_ID
+    grouped_data = join_data
+                     .drop(1)
+                     .group_by { |row| row.first.to_i }
+                     .transform_values { |values| values.map(&:last).map(&:to_i) }
 
+    # It returns the corresponding Tag record from the database based on the name
+    find_by_name = ->(tags_data, tag_id) do
+      _id, name, _language = tags_data.find { |row| row.first.to_i == tag_id }
+      Tag.find_by(name: name)
+    end
+
+    # Iterate over the dictionary of lists
+    grouped_data.each do |topic_id, tag_ids|
       topic = Topic.find_by(id: topic_id)
-      tag = ActsAsTaggableOn::Tag.find_by(id: tag_id)
-      next unless topic && tag
+      next if topic.nil?
 
-      unless topic.tag_list.include?(tag.name)
-        topic.tag_list.add(tag.name)
-        topic.save!
-      end
+      # Build a string with the tag names
+      tag_names_str = tag_ids.filter_map do |tag_id|
+        Tag.find_by(id: tag_id)&.name&.strip || find_by_name.(tags_data, tag_id)&.name&.strip
+      end.join(",")
+
+      # Set the topic tags in the pertinent context (language comes from the topic's language)
+      topic.set_tag_list_on(topic.language.code.to_sym, tag_names_str)
+      topic.save!
+
+      puts "#{topic.title} - #{topic.id} / Tags: #{topic.current_tags_list}"
     end
     puts "Topic tags import completed"
   end
@@ -159,7 +166,7 @@ class DataImport
 
     admin = User.find_by(email: "admin@mail.com")
     if admin.nil?
-      User.create!(email: "admin@mail.com", password: "test123", is_admin: true)
+      admin = User.create!(email: "admin@mail.com", password: "test123", is_admin: true)
     end
     Provider.all.each do |provider|
       provider.users << admin unless provider.users.include?(admin)
@@ -167,7 +174,7 @@ class DataImport
 
     me = User.find_by(email: "me@mail.com")
     if me.nil?
-     me = User.create!(email: "me@mail.com", password: "test123")
+      me = User.create!(email: "me@mail.com", password: "test123")
     end
 
     Provider.first.users << me unless Provider.first.users.include?(me)


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #120 

###
Tags are correctly imported with their original IDs 
Tag names are preserved
Topic tag associations are being created correctly for topics that exist
Found 3 topics in `topic_tags.csv` that don't exist in `topics_obfuscated.csv` 
Topic ID 1, Topic ID 5818, Topic ID 5819. The `import_topic_tag` method handles this by only creating associations for topics that exist

Something to note - 
The CSV is not ordered by ID. But when we look at the first 5 tags in the database, we see sequential IDs,  though the data is correct, I think.

There are 10 extra tags in the database vs CSV, which is interesting. Maybe the destroy method isn't working as it should. Is it possible this is because of seeds? It doesn't seem to affect the import process.
