### PR TITLE
Allow Admins to change provider when editing users

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -52,6 +52,6 @@ class ProvidersController < ApplicationController
     end
 
     def provider_params
-      params.expect(provider: [ :name, :provider_type, region_ids: [], user_ids: [] ])
+      params.expect(provider: [ :name, :provider_type, region_ids: [] ])
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,7 +50,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.expect(user: [ :email, :password, :is_admin ])
+    params.require(:user).permit(:email, :password, :is_admin, provider_ids: [])
   end
 
   def user_search_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,7 +50,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :password, :is_admin, provider_ids: [])
+    params.expect(user: [ :email, :password, :is_admin,  provider_ids: [] ])
   end
 
   def user_search_params

--- a/app/javascript/controllers/selectable_controller.js
+++ b/app/javascript/controllers/selectable_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus";
+import Tags from "bootstrap5-tags";
+
+export default class extends Controller {
+  static targets = ["selectableList"];
+
+  connect() {
+    this.initializeSelectables();
+  }
+
+  /**
+   * Initialize the input with given options
+   * @param {Object} options - Configuration options for bootstrap5-tags
+   */
+  initializeSelectables(options = {}, reset = false) {
+    Tags.init(`select#${this.selectableListTarget.id}`, options, reset);
+  }
+}

--- a/app/views/providers/_form.html.erb
+++ b/app/views/providers/_form.html.erb
@@ -32,13 +32,6 @@
     </div>
   </div>
 
-  <div class="col-md-4">
-    <div class="form-group">
-      <%= form.label :contributors, style: "display: block" %>
-      <%= form.collection_select :user_ids, User.order(:email), :id, :email, { include_hidden: false }, class: "form-select", multiple: true %>
-    </div>
-  </div>
-
   <div class="mt-4">
     <div class="col-12 d-flex justify-content-end">
       <%= form.submit class: "btn btn-primary me-1 mb-1" %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -41,7 +41,7 @@
         { prompt: "Select provider", include_blank: true },
         class: "form-select",
         multiple: true,
-        data: { "allow-new": "true", "allow-clear": "true", "selectable-target": "selectableList" }
+        data: { "allow-clear": "true", "not-found-message": "Please select a provider from the list", "selectable-target": "selectableList" }
       %>
     </div>
   </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -14,13 +14,13 @@
   <div class="col-md-4">
     <div class="form-group">
       <%= form.label :email, style: "display: block" %>
-      <%= form.text_field :email, id: "basicInput", class: "form-control", autofocus: true %>
+      <%= form.text_field :email, class: "form-control", autofocus: true %>
     </div>
   </div>
   <div class="col-md-4">
     <div class="form-group">
       <%= form.label :password, style: "display: block" %>
-      <%= form.text_field :password, id: "basicInput", class: "form-control", autofocus: true %>
+      <%= form.text_field :password, class: "form-control", autofocus: true %>
     </div>
   </div>
     <div class="col-md-4">
@@ -29,6 +29,23 @@
       <%= form.check_box :is_admin, autofocus: true %>
     </div>
   </div>
+
+  <div class="col-md-4" data-controller="selectable">
+    <div class="form-group">
+      <%= form.label :contributors, style: "display: block" %>
+      <%=
+        form.collection_select :provider_ids,
+        Provider.order(:name),
+        :id,
+        :name,
+        { prompt: "Select provider", include_blank: true },
+        class: "form-select",
+        multiple: true,
+        data: { "allow-new": "true", "allow-clear": "true", "selectable-target": "selectableList" }
+      %>
+    </div>
+  </div>
+
   <div class="mt-4">
     <div class="col-12 d-flex justify-content-end">
       <%= form.submit class: "btn btn-primary me-1 mb-1" %>

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "/users", type: :request do
   let(:admin) { create(:user, :admin) }
-  let(:provider_1) { FactoryBot.create(:provider) }
-  let(:provider_2) { FactoryBot.create(:provider) }
+  let(:provider_1) { create(:provider) }
+  let(:provider_2) { create(:provider) }
   let(:valid_attributes) do
       { email: "new_name@example.com",
         password: "new_password",
@@ -18,7 +18,6 @@ RSpec.describe "/users", type: :request do
 
   describe "GET /index" do
     it "renders a successful response" do
-      user = FactoryBot.create(:user)
       get users_url
       expect(response).to be_successful
     end
@@ -38,14 +37,16 @@ RSpec.describe "/users", type: :request do
 
   describe "POST /create" do
     context "with valid parameters" do
+      let(:user) { User.last }
+
       it "creates a new user with correct attributes and associations" do
         expect {
           post users_url, params: { user: valid_attributes }
         }.to change(User, :count).by(1)
-        expect(User.last.email).to eq("new_name@example.com")
-        expect(User.last.password_digest).not_to be_nil
-        expect(User.last.provider_ids).to match_array([ provider_1.id, provider_2.id ])
-        expect(User.last.is_admin).to be_falsey
+        expect(user.email).to eq("new_name@example.com")
+        expect(user.password_digest).not_to be_nil
+        expect(user.provider_ids).to match_array([ provider_1.id, provider_2.id ])
+        expect(user.is_admin).to be_falsey
       end
 
       it "redirects to the user index" do
@@ -69,16 +70,17 @@ RSpec.describe "/users", type: :request do
   end
 
   describe "GET /edit" do
+    let(:user) { create(:user) }
+
     it "renders a successful response" do
-      user = FactoryBot.create(:user)
       get edit_user_url(user)
       expect(response).to be_successful
     end
   end
 
   describe "PATCH /update" do
-    let(:user) { FactoryBot.create(:user, email: "old_name@example.com", password: "old_password") }
-    let(:previous_provider) { FactoryBot.create(:provider) }
+    let(:user) { create(:user, email: "old_name@example.com", password: "old_password") }
+    let(:previous_provider) { create(:provider) }
 
     before do
       user.contributors.create(provider_id: previous_provider.id)
@@ -108,15 +110,15 @@ RSpec.describe "/users", type: :request do
   end
 
   describe "DELETE /destroy" do
+    let!(:user) { create(:user, valid_attributes) }
+
     it "destroys the requested user" do
-      user = User.create! valid_attributes
       expect {
         delete user_url(user)
       }.to change(User, :count).by(-1)
     end
 
     it "redirects to the users list" do
-      user = User.create! valid_attributes
       delete user_url(user)
       expect(response).to redirect_to(users_url)
     end

--- a/spec/views/providers/edit.html.erb_spec.rb
+++ b/spec/views/providers/edit.html.erb_spec.rb
@@ -15,12 +15,4 @@ RSpec.describe "providers/edit", type: :view do
       assert_select "input[name=?]", "provider[provider_type]"
     end
   end
-
-  it "renders the contributor form group" do
-    render
-
-    assert_select "form[action=?][method=?]", provider_path(provider), "post" do
-      assert_select "select[id=?]", "provider_user_ids"
-    end
-  end
 end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #161 <!--fill issue number-->

### What Changed? And Why Did It Change?
Until now, we only allowed adding a user to a provider on the provider create or edit form, but the other users belonging to that provider were deselected when choosing a new user to add without pressing the multiselect key, so there was a risk of inadvertently removing users.

This commit moves the provider association management to the user form as this is probably more user-friendly, as discussed with @dcollie2 on Zoom and mentioned in issue [#161](https://github.com/rubyforgood/skillrx/issues/161).

### How Has This Been Tested?
In users_spec.rb and by hand

### Please Provide Screenshots
#### Before:
The only place where we could add a user to a Provider was on the Provider form:
![Capture d'écran 2025-05-06 234153](https://github.com/user-attachments/assets/27841cdd-1723-4260-bae1-5959f2b1ff90)

#### After:
We can add providers when creating a user:
![Capture d'écran 2025-05-06 233253](https://github.com/user-attachments/assets/5288c9de-c3af-4697-bc48-f293f9a1e797)

We can change providers when editing a user:
![Capture d'écran 2025-05-06 233320](https://github.com/user-attachments/assets/1ca65558-d438-4388-8091-4a8fba163150)

We can't add providers that don't exist:
![Provider dropdown invalid selection](https://github.com/user-attachments/assets/e342d772-3179-4894-8bbe-7ceb4c2354f3)

The Provider form no longer contains a fields for contributors:
![Capture d'écran 2025-05-06 233338](https://github.com/user-attachments/assets/91690ef1-981d-4dbe-a1c6-f9361c592c82)

But users are still visible on each Provider's #show page:
![Capture d'écran 2025-05-06 233351](https://github.com/user-attachments/assets/49c680ee-333c-44e5-9ca9-6fb1fd373e7f)


### Additional Comments
I wondered if I should re-use the select-tags JS controller but I thought the fact that there is a lot of logic in that controller that is specific to Tags (our Model, not Bootstrap tags) made it confusing, so I ended up extracting just what I needed in a selectable-controller that we could re-use on other Models that are not Tags. Let me know if you think this should be done differently.
