### PR TITLE
Destroy cognates when clearing all data

### DIFF
--- a/lib/autorequire/data_import.rb
+++ b/lib/autorequire/data_import.rb
@@ -5,6 +5,7 @@ class DataImport
   # Regions must be imported before providers
 
   def self.destroy_all_data
+    TagCognate.destroy_all
     ActsAsTaggableOn::Tagging.destroy_all
     ActsAsTaggableOn::Tag.destroy_all
     Topic.destroy_all


### PR DESCRIPTION
When deleting all data to prepare for an import, we need to clear the Tag Cognates. This fixes that.