### PR TITLE
Tag management fixes

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -66,7 +66,7 @@ class Tag < ActsAsTaggableOn::Tag
       next if name.blank?
 
       Tag.find_or_create_with_like_by_name(name).then do |tag|
-        tag_cognates.create(cognate: tag)
+        tag_cognates.find_or_create_by(cognate: tag)
       end
     end
   end

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -10,7 +10,7 @@
         <div data-controller="select-tags">
           <div class="form-group">
             <div class="d-flex">
-              <%= f.label "Cognates", class: "flex-fill" %>
+              <%= f.label :cognates_list, "Cognates", class: "flex-fill" %>
               <small class="flex-fill text-end fw-light text-muted text-uppercase">Press enter to add a new tag</small>
             </div>
             <%= f.select :cognates_list,

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -10,7 +10,7 @@
         <div data-controller="select-tags">
           <div class="form-group">
             <div class="d-flex">
-              <%= f.label :tag_list, class: "flex-fill" %>
+              <%= f.label "Cognates", class: "flex-fill" %>
               <small class="flex-fill text-end fw-light text-muted text-uppercase">Press enter to add a new tag</small>
             </div>
             <%= f.select :cognates_list,

--- a/app/views/topics/_search.html.erb
+++ b/app/views/topics/_search.html.erb
@@ -19,7 +19,6 @@
               <div class="form-group">
                 <div class="d-flex">
                   <%= f.label :tag_list, class: "flex-fill" %>
-                  <small class="flex-fill text-end fw-light text-muted text-uppercase">Press enter to add a new tag</small>
                 </div>
                 <%= f.select :tag_list,
                              options_from_collection_for_select(

--- a/spec/system/tag_update_spec.rb
+++ b/spec/system/tag_update_spec.rb
@@ -3,9 +3,11 @@ require "rails_helper"
 RSpec.describe "Updating a Tag", type: :system do
   let(:user) { create(:user, :admin) }
   let(:tag) { create(:tag, name: "Python") }
+  let(:cognate) { create(:tag, name: "Cython") }
 
   before do
     login_as(user)
+    create(:tag_cognate, tag: tag)
     wait_and_visit(edit_tag_path(tag.id))
   end
 


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #177 and #181

### What Changed? And Why Did It Change?

- Changed "Tag list" label to "Cognates" on the Tag form (#177)
- Fixed an issue that prevented us from adding new cognates when editing a Tag (#177)
- Removed a redundant sentence on the Topic search form (#181)

### How Has This Been Tested?
With RSpec and by hand

### Please Provide Screenshots
Removed redundant sentence:
![Topic search - issue 181](https://github.com/user-attachments/assets/1286fb06-00ca-4f9c-bf92-1caaa9de7cd1)

Fixed adding a cognate when editing a Tag:

https://github.com/user-attachments/assets/2a0b73bf-2f73-4e4d-bc43-8d86a604b8b1
