### PR TITLE
Add pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem "image_processing", "~> 1.14"
 
 gem "acts-as-taggable-on"
 gem "aws-sdk-s3", require: false
+gem "pagy"
 gem "requestjs-rails"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,7 @@ GEM
     nokogiri (1.18.8-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.1)
+    pagy (9.3.4)
     parallel (1.26.3)
     parser (3.3.7.2)
       ast (~> 2.4.1)
@@ -510,6 +511,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
+  pagy
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ RESET := \033[0m
 
 # Commands configuration
 COMPOSE_CMD = COMPOSE_PROJECT_NAME=$(PROJECT_NAME) docker compose -f docker-compose.dev.yml
-DOCKER_TEST_CMD = $(COMPOSE_CMD) exec app bundle exec rspec --format documentation
+DOCKER_TEST_CMD = $(COMPOSE_CMD) exec app bundle exec bash -c "export RAILS_ENV=test && rspec --format documentation"
 EXEC_CMD = $(COMPOSE_CMD) exec app
 
 .PHONY: help build rebuild stop start restart logs shell console format test test_fast db_reset migrate clean clean_volumes
@@ -69,7 +69,7 @@ format:
 	$(EXEC_CMD) bundle exec rubocop --autocorrect-all
 
 test:
-	export RAILS_ENV=test $(DOCKER_TEST_CMD)
+	$(DOCKER_TEST_CMD)
 
 test_fast:
 	$(DOCKER_TEST_CMD) --fail-fast

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,9 +1,11 @@
 
 class TagsController < ApplicationController
+  include Pagy::Backend
+
   before_action :set_tag, only: [ :show, :edit, :update, :destroy ]
 
   def index
-    @tags = Tag.includes(:cognates, :reverse_cognates).references(:tag)
+    @pagy, @tags = pagy(Tag.includes(:cognates, :reverse_cognates).references(:tag))
   end
 
   def new

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,8 +1,10 @@
 class TopicsController < ApplicationController
+  include Pagy::Backend
+
   before_action :set_topic, only: [ :show, :edit, :tags, :update, :destroy, :archive ]
 
   def index
-    @topics = scope.search_with_params(search_params)
+    @pagy, @topics = pagy(scope.search_with_params(search_params))
     @available_providers = other_available_providers
     @languages = scope.map(&:language).uniq.sort_by(&:name)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,11 @@
 class UsersController < ApplicationController
+  include Pagy::Backend
+
   before_action :redirect_contributors
   before_action :set_user, only: %i[ edit update destroy ]
 
   def index
-    @users = User.all.search_with_params(user_search_params)
+    @pagy, @users = pagy(User.all.search_with_params(user_search_params))
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include Pagy::Frontend
+
   def flash_class(level)
     case level
     when "notice" then "alert-light-success"

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -28,6 +28,9 @@
             </div>
           </div>
         </div>
+        <div class="card-footer d-flex justify-content-end">
+          <%== pagy_bootstrap_nav(@pagy) %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -38,6 +38,9 @@
               <% end %>
             </div>
           </div>
+          <div class="card-footer d-flex justify-content-end">
+            <%== pagy_bootstrap_nav(@pagy) %>
+          </div>
         </div>
       <% end %>
     </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -71,6 +71,9 @@
           <tbody>
         </table>
       </div>
+      <div class="card-footer d-flex justify-content-end">
+        <%== pagy_bootstrap_nav(@pagy) %>
+      </div>
     </div>
   </section>
 </div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (9.3.3)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
+# You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+# Here are the few that make more sense as DEFAULTs:
+# Pagy::DEFAULT[:limit]       = 20                    # default
+# Pagy::DEFAULT[:size]        = 7                     # default
+# Pagy::DEFAULT[:ends]        = true                  # default
+# Pagy::DEFAULT[:page_param]  = :page                 # default
+# Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
+# Pagy::DEFAULT[:max_pages]   = 3000                  # example
+
+
+# Extras
+# See https://ddnexus.github.io/pagy/categories/extra
+
+
+# Legacy Compatibility Extras
+
+# Size extra: Enable the Array type for the `:size` variable (e.g. `size: [1,4,4,1]`)
+# See https://ddnexus.github.io/pagy/docs/extras/size
+# require 'pagy/extras/size'   # must be required before the other extras
+
+
+# Backend Extras
+
+# Arel extra: For better performance utilizing grouped ActiveRecord collections:
+# See: https://ddnexus.github.io/pagy/docs/extras/arel
+# require 'pagy/extras/arel'
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/docs/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/docs/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each calendar unit class in IRB:
+# >> Pagy::Calendar::Year::DEFAULT
+# >> Pagy::Calendar::Quarter::DEFAULT
+# >> Pagy::Calendar::Month::DEFAULT
+# >> Pagy::Calendar::Week::DEFAULT
+# >> Pagy::Calendar::Day::DEFAULT
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/docs/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See https://ddnexus.github.io/pagy/docs/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
+#                            limit: 'Page-Items',
+#                            count: 'Total-Count',
+#                            pages: 'Total-Pages' }     # default
+
+# Keyset extra: Paginate with the Pagy keyset pagination technique
+# See https://ddnexus.github.io/pagy/docs/extras/keyset
+# require 'pagy/extras/keyset'
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/docs/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/docs/extras/metadata
+# you must require the JS Tools internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/js_tools'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# Pagy::DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bootstrap
+require "pagy/extras/bootstrap"
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Pagy extra: Add the pagy styled versions of the javascript-powered navs
+# and a few other components to the Pagy::Frontend module.
+# See https://ddnexus.github.io/pagy/docs/extras/pagy
+# require 'pagy/extras/pagy'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/docs/extras/pagy#steps
+# Pagy::DEFAULT[:steps] = { 0 => 5, 540 => 7, 720 => 9 }   # example
+
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the limit per page depending on the page number
+# See https://ddnexus.github.io/pagy/docs/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_limit] = [15, 30, 60, 100]   # default
+
+# Limit extra: Allow the client to request a custom limit per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/docs/extras/limit
+# require 'pagy/extras/limit'
+# set to false only if you want to make :limit_extra an opt-in variable
+# Pagy::DEFAULT[:limit_extra] = false    # default true
+# Pagy::DEFAULT[:limit_param] = :limit   # default
+# Pagy::DEFAULT[:limit_max]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/docs/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/docs/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/docs/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+# Jsonapi extra: Implements JSON:API specifications
+# See https://ddnexus.github.io/pagy/docs/extras/jsonapi
+# require 'pagy/extras/jsonapi'   # must be required after the other extras
+# set to false only if you want to make :jsonapi an opt-in variable
+# Pagy::DEFAULT[:jsonapi] = false  # default true
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_limit_selector_js)
+# See https://ddnexus.github.io/pagy/docs/api/javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/docs/api/i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/docs/extras/i18n
+require "pagy/extras/i18n"
+
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze

--- a/config/locales/pagy.en.yml
+++ b/config/locales/pagy.en.yml
@@ -1,0 +1,4 @@
+en:
+  pagy:
+    prev: "Previous"
+    next: "Next"

--- a/lib/autorequire/data_import.rb
+++ b/lib/autorequire/data_import.rb
@@ -3,6 +3,10 @@ class DataImport
 
   # There are dependencies here.
   # Regions must be imported before providers
+  def self.reset
+    self.destroy_all_data
+    self.import_all
+  end
 
   def self.destroy_all_data
     TagCognate.destroy_all

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -14,7 +14,9 @@
 #
 FactoryBot.define do
   factory :tag do
-    name { Faker::ProgrammingLanguage.name }
+    sequence(:name) do |n|
+      Faker::ProgrammingLanguage.name + n.to_s
+    end
 
     trait :english do
       after(:build) do |tag|

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
   factory :topic do
     association :provider
     association :language
-    title { "topic title" }
+    sequence(:title) { |n| "topic title #{10}" }
     description { "many topic details" }
     published_at { DateTime.new(2023, 1, 1) }
     state { 0 }

--- a/spec/requests/topics/create_spec.rb
+++ b/spec/requests/topics/create_spec.rb
@@ -6,7 +6,7 @@ describe "Topics", type: :request do
     let(:provider) { create(:provider) }
     let(:language) { create(:language) }
     let(:topic_params) do
-      attributes_for(:topic, provider_id: provider.id, language_id: language.id).tap do |params|
+      attributes_for(:topic, title: "topic title", provider_id: provider.id, language_id: language.id).tap do |params|
         params[:published_at_year] = params[:published_at].year
         params[:published_at_month] = params[:published_at].month
         params[:published_at] = nil

--- a/spec/views/tags/index.html.erb_spec.rb
+++ b/spec/views/tags/index.html.erb_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "tags/index", type: :view do
+  context "when there are no tags" do
+    before(:each) do
+      assign(:pagy, Pagy.new(count: 0))
+      assign(:tags, [])
+    end
+
+    it "renders no tags" do
+      render
+      assert_select "table>tbody>tr", count: 0
+    end
+  end
+
+  context "when there are tags but only one page" do
+    before(:each) do
+      assign(:pagy, Pagy.new(count: 1))
+      assign(:tags, [ create(:tag, name: "Tag 1") ])
+    end
+
+    it "renders a list of tags" do
+      render
+      assert_select "table>tbody>tr", count: 1
+    end
+
+    it "renders pagination nav without page links" do
+      render
+      assert_dom "nav.pagy-bootstrap .page-link", text: "1", count: 1
+    end
+  end
+
+  context "when there are multiple pages of tags" do
+    before(:each) do
+      # Simulate being on page 2 with 10 items per page and 25 total items
+      pagy = Pagy.new(count: 25, page: 2, items: 10)
+      assign(:pagy, pagy)
+      assign(:tags, create_list(:tag, 10))
+    end
+
+    it "renders the current page of tags" do
+      render
+      assert_select "table>tbody>tr", count: 10
+    end
+
+    it "renders pagination with multiple pages" do
+      render
+      assert_select "nav.pagy-bootstrap .page-item", minimum: 2
+      assert_dom "nav.pagy-bootstrap .page-item.active", text: "2", count: 1
+    end
+  end
+end

--- a/spec/views/topics/index.html.erb_spec.rb
+++ b/spec/views/topics/index.html.erb_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "topics/index", type: :view do
+  before(:each) do
+    def view.search_params = {}
+    def view.topics_title = "Topics"
+
+    # Allow the original render method to work normally
+    allow(view).to receive(:render).and_call_original
+    # But stub specifically the search partial render
+    allow(view).to receive(:render).with("search", any_args).and_return("")
+
+    assign(:available_providers, [])
+  end
+
+  context "when there are no topics" do
+    before(:each) do
+      assign(:pagy, Pagy.new(count: 0))
+      assign(:topics, [])
+    end
+
+    it "renders no topics" do
+      render
+      assert_select "table>tbody>tr", count: 0
+    end
+  end
+
+  context "when there are topics but only one page" do
+    before(:each) do
+      assign(:pagy, Pagy.new(count: 1))
+      assign(:topics, [ create(:topic, title: "Topic 1") ])
+    end
+
+    it "renders a list of topics" do
+      render
+      assert_select "table>tbody>tr", count: 1
+    end
+
+    it "renders pagination nav with unique item" do
+      render
+      assert_dom "nav.pagy-bootstrap .page-item", text: "1", count: 1
+    end
+  end
+
+  context "when there are multiple pages of topics" do
+    before(:each) do
+      # Simulate being on page 2 with 10 items per page and 25 total items
+      pagy = Pagy.new(count: 25, page: 2, items: 10)
+      assign(:pagy, pagy)
+      assign(:topics, create_list(:topic, 10))
+    end
+
+    it "renders the current page of topics" do
+      render
+      assert_select "table>tbody>tr", count: 10
+    end
+
+    it "renders pagination with multiple pages" do
+      render
+      assert_select "nav.pagy-bootstrap .page-item", minimum: 2
+      assert_dom "nav.pagy-bootstrap .page-item.active", text: "2", count: 1
+    end
+  end
+end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "users/index", type: :view do
+  context "when there are no users" do
+    before(:each) do
+      assign(:pagy, Pagy.new(count: 0))
+      assign(:users, [])
+    end
+
+    it "renders no users" do
+      render
+      assert_select "table>tbody>tr", count: 0
+    end
+  end
+
+  context "when there are users but only one page" do
+    before(:each) do
+      assign(:pagy, Pagy.new(count: 1))
+      assign(:users, [ create(:user, email: "user@test.local") ])
+    end
+
+    it "renders a list of users" do
+      render
+      assert_select "table>tbody>tr", count: 1
+    end
+
+    it "renders pagination nav without page links" do
+      render
+      assert_dom "nav.pagy-bootstrap .page-link", text: "1", count: 1
+    end
+  end
+
+  context "when there are multiple pages of users" do
+    before(:each) do
+      # Simulate being on page 2 with 10 items per page and 25 total items
+      pagy = Pagy.new(count: 25, page: 2, items: 10)
+      assign(:pagy, pagy)
+      assign(:users, create_list(:user, 10))
+    end
+
+    it "renders the current page of users" do
+      render
+      assert_select "table>tbody>tr", count: 10
+    end
+
+    it "renders pagination with multiple pages" do
+      render
+      assert_select "nav.pagy-bootstrap .page-item", minimum: 2
+      assert_dom "nav.pagy-bootstrap .page-item.active", text: "2", count: 1
+    end
+  end
+end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #195 

### What Changed? And Why Did It Change?
As we begin testing the application with data similar to that in production, we have noticed that some index pages are loading too slowly. We decided to paginate the index pages of:
- Users
- Topics
- Tags

The pagination is implemented through the[ Pagy gem.](https://github.com/ddnexus/pagy)

### How Has This Been Tested?
- View tests were added

### Please Provide Screenshots

<img width="1483" alt="Screenshot 2025-06-08 at 16 00 07" src="https://github.com/user-attachments/assets/846d482b-3042-4314-993c-2f66bf8d8654" />

<img width="1476" alt="Screenshot 2025-06-08 at 16 00 28" src="https://github.com/user-attachments/assets/c9fc6c8c-249f-40c2-a1c5-e0367d059fb0" />

<img width="1484" alt="Screenshot 2025-06-08 at 15 59 47" src="https://github.com/user-attachments/assets/a77cbe97-c83b-4073-8c21-a5683067b0cc" />
