### PR TITLE
Import training documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ RESET := \033[0m
 
 # Commands configuration
 COMPOSE_CMD = COMPOSE_PROJECT_NAME=$(PROJECT_NAME) docker compose -f docker-compose.dev.yml
-DOCKER_TEST_CMD = $(COMPOSE_CMD) exec app bundle exec bash -c "export RAILS_ENV=test && rspec --format documentation"
 EXEC_CMD = $(COMPOSE_CMD) exec app
 
 .PHONY: help build rebuild stop start restart logs shell console format test test_fast db_reset migrate clean clean_volumes
@@ -69,10 +68,10 @@ format:
 	$(EXEC_CMD) bundle exec rubocop --autocorrect-all
 
 test:
-	$(DOCKER_TEST_CMD)
+	$(COMPOSE_CMD) exec app bundle exec bash -c "export RAILS_ENV=test && rspec --format documentation"
 
 test_fast:
-	$(DOCKER_TEST_CMD) --fail-fast
+	$(COMPOSE_CMD) exec app bundle exec bash -c "export RAILS_ENV=test && rspec --format documentation --fail-fast"
 
 migrate:
 	$(EXEC_CMD) bundle exec rails db:migrate

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,4 +1,5 @@
 class TopicsController < ApplicationController
+  include ActiveStorage::SetCurrent
   include Pagy::Backend
 
   before_action :set_topic, only: [ :show, :edit, :tags, :update, :destroy, :archive ]

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -1,0 +1,39 @@
+module TopicsHelper
+  def card_preview_media(file)
+    case file.content_type
+    in /image/ then render_image(file)
+    in /pdf/ then render_pdf(file)
+    in /video/ then render_video(file)
+    in /audio/ then render_audio(file)
+    else render_download_link(file)
+    end
+  end
+
+  private
+
+  def render_image(file)
+    image_tag(file.url, class: "img-fluid w-100")
+  end
+
+  def render_pdf(file)
+    content_tag(:div, class: "embed-responsive embed-responsive-item embed-responsive-16by9 w-100") do
+      content_tag(:object, data: file.url, type: "application/pdf", width: "100%", height: "400px") do
+        content_tag(:iframe, "", src: file.url, width: "100%", height: "100%", style: "border: none;") do
+          content_tag(:p, "Your browser does not support PDF viewing. #{link_to('Download the PDF', file.url)}")
+        end
+      end
+    end
+  end
+
+  def render_video(file)
+    video_tag(file.url, style: "width: 100%")
+  end
+
+  def render_audio(file)
+    audio_tag(file.url, controls: true, style: "width: 100%")
+  end
+
+  def render_download_link(file)
+    link_to file.filename, file.url
+  end
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -26,7 +26,7 @@ class Topic < ApplicationRecord
   include Taggable
 
   STATES = %i[active archived].freeze
-  CONTENT_TYPES = %w[image/jpeg image/png image/svg+xml image/webp image/avif image/gif video/mp4 application/pdf].freeze
+  CONTENT_TYPES = %w[image/jpeg image/png image/svg+xml image/webp image/avif image/gif video/mp4 application/pdf audio/mpeg].freeze
 
   belongs_to :language
   belongs_to :provider

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -33,7 +33,7 @@ class Topic < ApplicationRecord
   has_many_attached :documents
 
   validates :title, :language_id, :provider_id, :published_at, presence: true
-  validates :documents, content_type: CONTENT_TYPES, size: { less_than: 10.megabytes }
+  validates :documents, content_type: CONTENT_TYPES, size: { less_than: 200.megabytes }
 
   enum :state, STATES.map.with_index.to_h
 

--- a/app/views/topics/_topic.html.erb
+++ b/app/views/topics/_topic.html.erb
@@ -1,42 +1,47 @@
 <div id="<%= dom_id topic %>">
   <div class="section">
-    <p>
-      <strong>UID:</strong>
-      <%= topic.uid %>
-    </p>
-    <p>
-      <strong>Title:</strong>
-      <%= topic.title %>
-    </p>
-    <p>
-      <strong>Description:</strong>
-      <%= topic.description %>
-    </p>
-    <p>
-      <strong>Provider:</strong>
-      <%= link_to topic.provider.name, topic.provider %>
-    </p>
-    <p>
-      <strong>Language:</strong>
-      <%= link_to topic.language.name, topic.language %>
-    </p>
-    <p>
-      <strong>Publishing at:</strong>
-      <%= topic.published_at.strftime('%m/%d/%Y') %>
-    </p>
-    <div>
-      <p>
+    <h3 class="mb-4">Topic: <%= topic.id %></h3>
+    <div class="card mb-6">
+      <div class="card-header">
+        <div class="card-title">
+          <h3><%= topic.title %></h3>
+        </div>
+      </div>
+      <div class="card-body">
+        <div class="row mb-2">
+          <div class="col-md-3"><strong>UID:</strong></div>
+          <div class="col-md-9"><%= topic.uid %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-md-3"><strong>Description:</strong></div>
+          <div class="col-md-9"><%= topic.description %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-md-3"><strong>Provider:</strong></div>
+          <div class="col-md-9"><%= link_to topic.provider.name, topic.provider, class: "text-decoration-none" %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-md-3"><strong>Language:</strong></div>
+          <div class="col-md-9"><%= link_to topic.language.name, topic.language, class: "text-decoration-none" %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-md-3"><strong>Publishing at:</strong></div>
+          <div class="col-md-9"><%= topic.published_at.strftime('%m/%d/%Y') %></div>
+        </div>
+      </div>
+      <div class="card-footer">
         <strong>Tags:</strong>
         <% topic.current_tags.each do |tag| %>
-          <%= link_to tag.name, tag_path(tag), class: "badge bg-success", target: "_blank" %>
+          <%= link_to tag.name, tag_path(tag), class: "badge bg-success text-decoration-none me-1", target: "_blank" %>
         <% end %>
-      </p>
+      </div>
     </div>
   </div>
 
   <div class="section">
-    <h4>Documents</h4>
-    <hr>
+    <div class="col-12">
+      <h3 class="mb-4">Documents</h3>
+    </div>
     <div>
       <% topic.documents.each do |document| %>
         <div class="card">

--- a/app/views/topics/_topic.html.erb
+++ b/app/views/topics/_topic.html.erb
@@ -1,49 +1,74 @@
 <div id="<%= dom_id topic %>">
-  <p>
-    <strong>UID:</strong>
-    <%= topic.uid %>
-  </p>
-
-  <p>
-    <strong>Title:</strong>
-    <%= topic.title %>
-  </p>
-
-  <p>
-    <strong>Description:</strong>
-    <%= topic.description %>
-  </p>
-
-  <p>
-    <strong>Provider:</strong>
-    <%= link_to topic.provider.name, topic.provider %>
-  </p>
-
-  <p>
-    <strong>Language:</strong>
-    <%= link_to topic.language.name, topic.language %>
-  </p>
-
-  <p>
-    <strong>Publishing at:</strong>
-    <%= topic.published_at.strftime('%m/%d/%Y') %>
-  </p>
-
-  <div>
+  <div class="section">
     <p>
-      <strong>Tags:</strong>
-      <% topic.current_tags.each do |tag| %>
-        <%= link_to tag.name, tag_path(tag), class: "badge bg-success", target: "_blank" %>
-      <% end %>
+      <strong>UID:</strong>
+      <%= topic.uid %>
     </p>
+    <p>
+      <strong>Title:</strong>
+      <%= topic.title %>
+    </p>
+    <p>
+      <strong>Description:</strong>
+      <%= topic.description %>
+    </p>
+    <p>
+      <strong>Provider:</strong>
+      <%= link_to topic.provider.name, topic.provider %>
+    </p>
+    <p>
+      <strong>Language:</strong>
+      <%= link_to topic.language.name, topic.language %>
+    </p>
+    <p>
+      <strong>Publishing at:</strong>
+      <%= topic.published_at.strftime('%m/%d/%Y') %>
+    </p>
+    <div>
+      <p>
+        <strong>Tags:</strong>
+        <% topic.current_tags.each do |tag| %>
+          <%= link_to tag.name, tag_path(tag), class: "badge bg-success", target: "_blank" %>
+        <% end %>
+      </p>
+    </div>
   </div>
 
-  <div>
-    <strong>Documents:</strong>
-    <ul>
+  <div class="section">
+    <h4>Documents</h4>
+    <hr>
+    <div>
       <% topic.documents.each do |document| %>
-        <li><%= link_to document.filename, rails_blob_path(document), target: "_blank"%></li>
+        <div class="card">
+          <div class="card-content">
+            <div class="card-body">
+              <div class="card-title">
+                <h4><%= document.filename %></h4>
+              </div>
+            </div>
+
+            <%= card_preview_media(document) %>
+
+            <div class="card-body">
+              <div class="d-flex justify-content-between">
+                <div>
+                  <span class="btn btn-sm btn-outline-secondary">
+                    <i class="bi bi-calendar-date"></i>
+                    <%= document.created_at.strftime('%m/%d/%Y') %>
+                  </span>
+                  <span class="btn btn-sm btn-outline-secondary">
+                    <i class="bi bi-clipboard-data"></i>
+                    <%= number_to_human_size(document.byte_size) %>
+                  </span>
+                </div>
+                <%= link_to rails_blob_path(document), target: "_blank", class: "btn btn-primary" do %>
+                  <i class="bi bi-file-arrow-down"></i> Download
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
       <% end %>
-    </ul>
+    </div>
   </div>
 </div>

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe TopicsHelper, type: :helper do
+  describe "#card_preview_media" do
+    let(:topic) { create(:topic, :with_documents) }
+
+    before(:each) do
+      ActiveStorage::Current.url_options = { host: "localhost:3000" }
+    end
+
+    context "when file is an image" do
+      it "renders an image tag" do
+        result = helper.card_preview_media(topic.documents.first)
+        expect(result).to include("img-fluid")
+        expect(result).to include("src=")
+      end
+    end
+
+    context "when file is a PDF" do
+      before do
+        blob = ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("PDF content"),
+          filename: "test.pdf",
+          content_type: "application/pdf"
+        )
+        topic.documents.attach(blob)
+      end
+
+      it "renders a PDF viewer" do
+        result = helper.card_preview_media(topic.documents.last)
+        expect(result).to include("application/pdf")
+        expect(result).to include("object")
+      end
+    end
+
+    context "when file is a video" do
+      before do
+        blob = ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("Video content"),
+          filename: "test_video.mp4",
+          content_type: "video/mp4"
+        )
+        topic.documents.attach(blob)
+      end
+
+      it "renders a video tag" do
+        result = helper.card_preview_media(topic.documents.last)
+        expect(result).to include("video")
+      end
+    end
+
+    context "when file is of an unknown type" do
+      before do
+        blob = ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("Text content"),
+          filename: "test.txt",
+          content_type: "text/plain"
+        )
+        topic.documents.attach(blob)
+      end
+
+      it "renders a download link" do
+        result = helper.card_preview_media(topic.documents.last)
+        expect(result).to include("href=")
+        expect(result).to include("test.txt")
+      end
+    end
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Topic, type: :model do
   context "associations" do
     it { should have_many_attached(:documents) }
     it { is_expected.to validate_content_type_of(:documents).allowing("image/png", "image/jpeg", "image/svg+xml", "image/webp", "image/avif", "image/gif", "video/mp4") }
-    it { is_expected.to validate_size_of(:documents).less_than(10.megabytes) }
+    it { is_expected.to validate_size_of(:documents).less_than(200.megabytes) }
   end
 
   context "tagging" do

--- a/spec/requests/topics/show_spec.rb
+++ b/spec/requests/topics/show_spec.rb
@@ -21,7 +21,7 @@ describe "Topics", type: :request do
       it "displays a link to the document" do
         get topic_path(topic)
 
-        expect(page).to have_link("logo_ruby_for_good.png")
+        expect(response.body).to include("logo_ruby_for_good.png")
       end
     end
   end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #119 

### What Changed? And Why Did It Change?
- Import for training documents is in place, check `DataImport.import_training_documents`
- `card_preview_media` was introduced to show topic documents in the browser using HTML5 tags

### How Has This Been Tested?
Locally using the Localstack service as the active storage provider

### Please Provide Screenshots
#### Topic show
![Screen Shot 2025-06-19 at 16 56 37](https://github.com/user-attachments/assets/14a5b313-4958-4c3d-98e6-1a032bff3466)

#### Localstack logs
<img width="818" alt="Screenshot 2025-06-19 at 16 55 26" src="https://github.com/user-attachments/assets/6db2ca2e-9823-4f94-b5d1-10e97eb5f819" />

