### PR TITLE
Topic params sanitizer 150

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ end
 
 group :test do
   gem "capybara"
+  gem "database_cleaner"
   gem "rails-controller-testing"
   gem "selenium-webdriver"
   gem "shoulda-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,12 @@ GEM
     connection_pool (2.5.3)
     crass (1.0.6)
     csv (3.3.5)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -512,6 +518,7 @@ DEPENDENCIES
   bullet
   capybara
   csv
+  database_cleaner
   debug
   dotenv-rails
   factory_bot_rails

--- a/app/controllers/topics/tags_controller.rb
+++ b/app/controllers/topics/tags_controller.rb
@@ -1,0 +1,20 @@
+class Topics::TagsController < ApplicationController
+  before_action :set_topic
+
+  def index
+    return [] unless params[:topic_id].present? && tags_params[:language_id].present?
+
+    @tags = @topic.current_tags_for_language(tags_params[:language_id])
+    render json: @tags
+  end
+
+  private
+
+  def tags_params
+    params.permit(:language_id)
+  end
+
+  def set_topic
+    @topic = Topic.find(params[:topic_id])
+  end
+end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -2,7 +2,7 @@ class TopicsController < ApplicationController
   include ActiveStorage::SetCurrent
   include Pagy::Backend
 
-  before_action :set_topic, only: [ :show, :edit, :tags, :update, :destroy, :archive ]
+  before_action :set_topic, only: [ :show, :edit, :update, :destroy, :archive ]
 
   def index
     @pagy, @topics = pagy(scope.includes(:documents_attachments).search_with_params(search_params))
@@ -50,13 +50,6 @@ class TopicsController < ApplicationController
     redirect_to topics_path
   end
 
-  def tags
-    return [] unless params[:id].present? && topic_tags_params[:language_id].present?
-
-    @tags = @topic.current_tags_for_language(topic_tags_params[:language_id])
-    render json: @tags
-  end
-
   private
 
   def attach_files(signed_ids)
@@ -93,10 +86,6 @@ class TopicsController < ApplicationController
 
   def scope
     @scope ||= current_provider.topics.includes(:language)
-  end
-
-  def topic_tags_params
-    params.permit(:language_id)
   end
 
   def search_params

--- a/app/sanitizers/topic_sanitizer.rb
+++ b/app/sanitizers/topic_sanitizer.rb
@@ -1,16 +1,15 @@
 class TopicSanitizer
-  attr_accessor :params, :provider_scope, :current_provider
-
-  def initialize(params, provider_scope, current_provider)
+  def initialize(params:, provider:, provider_scope:)
     @params = params
+    @provider = provider
     @provider_scope = provider_scope
-    @current_provider = current_provider
   end
 
   def sanitize
     params
       .then { validate_provider!(_1) }
       .then { validate_published_at!(_1) }
+      .then { validate_blobs!(_1) }
       .tap do |p|
         p["title"] = p["title"].strip if p["title"].present?
         p["description"] = p["description"].strip if p["description"].present?
@@ -24,7 +23,7 @@ class TopicSanitizer
 
     params.tap do |p|
       p["provider_id"] = provider_scope.find(p["provider_id"]).id
-      p["provider_id"] = current_provider.id if current_provider && !Current.user.is_admin?
+      p["provider_id"] = provider.id if provider && !Current.user.is_admin?
     end
   end
 
@@ -38,4 +37,24 @@ class TopicSanitizer
       p.delete("published_at_month")
     end
   end
+
+  def validate_blobs!(params)
+    return params if params[:document_signed_ids].blank?
+
+    params[:document_signed_ids] = params[:document_signed_ids].filter_map do |signed_id|
+      blob = ActiveStorage::Blob.find_signed(signed_id)
+      next if blob.blank?
+
+      if blob.content_type.in?(Topic::CONTENT_TYPES) && blob.byte_size < 10.megabytes
+        next signed_id
+      end
+
+      blob.purge
+      nil
+    end
+
+    params
+  end
+
+  attr_accessor :params, :provider_scope, :provider
 end

--- a/app/sanitizers/topic_sanitizer.rb
+++ b/app/sanitizers/topic_sanitizer.rb
@@ -1,0 +1,41 @@
+class TopicSanitizer
+  attr_accessor :params, :provider_scope, :current_provider
+
+  def initialize(params, provider_scope, current_provider)
+    @params = params
+    @provider_scope = provider_scope
+    @current_provider = current_provider
+  end
+
+  def sanitize
+    params
+      .then { validate_provider!(_1) }
+      .then { validate_published_at!(_1) }
+      .tap do |p|
+        p["title"] = p["title"].strip if p["title"].present?
+        p["description"] = p["description"].strip if p["description"].present?
+      end
+  end
+
+  private
+
+  def validate_provider!(params)
+    return params if params["provider_id"].blank?
+
+    params.tap do |p|
+      p["provider_id"] = provider_scope.find(p["provider_id"]).id
+      p["provider_id"] = current_provider.id if current_provider && !Current.user.is_admin?
+    end
+  end
+
+  def validate_published_at!(params)
+    year = params["published_at_year"].present? ? params["published_at_year"].to_i : Time.current.year
+    month = params["published_at_month"].present? ? params["published_at_month"].to_i : Time.current.month
+
+    params.tap do |p|
+      p["published_at"] = DateTime.new(year, month, 1)
+      p.delete("published_at_year")
+      p.delete("published_at_month")
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,8 @@ Rails.application.routes.draw do
   resources :topics do
     member do
       put :archive
-      get :tags
     end
+    resources :tags, only: %i[index], controller: "topics/tags"
   end
   resource :settings, only: [] do
     put :provider, on: :collection

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,26 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:deletion)
+  end
+
+  config.before do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :deletion
+  end
+
+  config.before(database_cleaner: :deletion) do
+    DatabaseCleaner.strategy = :deletion
+  end
+
+  config.before do
+    DatabaseCleaner.start
+  end
+
+  config.after do
+    Capybara.reset_sessions!
+    DatabaseCleaner.clean
+  end
+end

--- a/spec/system/upload_management_spec.rb
+++ b/spec/system/upload_management_spec.rb
@@ -76,7 +76,9 @@ RSpec.describe "Upload Management", type: :system do
           expect(page).to have_text("logo_ruby_for_good.png")
           expect(page).to have_text("file_text_test.txt")
           click_button("Update Topic")
-          expect(page).to have_text("Documents must be images, videos or PDFs")
+          expect(page).to have_text("View")
+          click_link("View", href: topic_path(topic))
+          expect(page).not_to have_text("file_text_test.txt")
         end
       end
     end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #150 

### What Changed? And Why Did It Change?

* added topic params sanitizer to extract this responsibility into separate class
* added `database_cleaner` gem because our test suite requires cleaning between runs
* topics topic tags actions into separate controller
* added blob validation to sanitising logic, it does not throw error anymore

### How Has This Been Tested?

Updated some tests + manually checked

### Please Provide Screenshots

### Additional Comments

See comments for PR