### PR TITLE
Add search for Tag index

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -5,7 +5,7 @@ class TagsController < ApplicationController
   before_action :set_tag, only: [ :show, :edit, :update, :destroy ]
 
   def index
-    @pagy, @tags = pagy(Tag.includes(:cognates, :reverse_cognates).references(:tag))
+    @pagy, @tags = pagy(Tag.includes(:cognates, :reverse_cognates).references(:tag).search_with_params(tag_search_params))
   end
 
   def new
@@ -54,6 +54,11 @@ class TagsController < ApplicationController
 
   def tag_params
     params.require(:tag).permit(:name, cognates_list: [])
+  end
+
+  def tag_search_params
+    return {} unless params[:search].present?
+    params.expect(search: [ :name, :order ])
   end
 
   def set_tag

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -12,7 +12,27 @@
         </div>
         <div class="card-content">
           <div class="card-body">
-            <p class="card-text">Some important information or instruction can be placed here.</p>
+            <%= form_for :search, url: tags_path, method: :get, data: { controller: "search", search_target: "search", turbo_frame: "tag-list", turbo_action: "advance" } do |f| %>
+              <div class="form-body">
+                <div class="row">
+                  <div class="col-md-6 col-12">
+                    <div class="form-group">
+                      <%= f.label :name %>
+                      <%= f.text_field :name, value: params.dig(:search, :name), class: "form-control", data: { action: "input->search#submit" } %>
+                    </div>
+                  </div>
+                  <div class="col-md-6 col-12">
+                    <div class="form-group">
+                      <%= f.label :order, "Order by" %>
+                      <%= f.select :order, options_for_select([["Name", :name],["Most recently added", :desc], ["Least recently added", :asc], ["Highest number of taggings", :most_tagged], ["Lowest number of taggings", :least_tagged]], params.dig(:search, :order)), {}, class: "form-select", data: { action: "change->search#submit" } %>
+                    </div>
+                  </div>
+                  <div class="col-12 d-flex justify-content-end">
+                    <%= link_to "Clear", tags_path, class: "btn btn-light-secondary me-1 mb-1" %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
             <div class="table-responsive">
               <table class="table table-lg table-striped mb-0">
                 <thead>

--- a/spec/system/tag_search_spec.rb
+++ b/spec/system/tag_search_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "Tag search", type: :system do
+  let(:admin) { create(:user, :admin) }
+  let!(:tag_1) { create(:tag, name: "Acupuncture", created_at: 3.days.ago, taggings_count: 2) }
+  let!(:tag_2) { create(:tag, name: "Macular Degeneration", created_at: 1.day.ago, taggings_count: 1) }
+  let!(:tag_3) { create(:tag, name: "Transplant", created_at: 2.days.ago, taggings_count: 3) }
+
+  before do
+    login_as(admin)
+    click_link("Tags")
+  end
+
+  it "shows by default the tags in alphabetical order" do
+    expect(page).to have_text(/Acupuncture.+Macular Degeneration.+Transplant/m)
+  end
+
+  context "when searching by name" do
+    it "only displays tags matching the search" do
+      fill_in "search[name]", with: "acu"
+
+      expect(page).to have_text("Acupuncture")
+      expect(page).to have_text("Macular Degeneration")
+      expect(page).not_to have_text("Transplant")
+    end
+  end
+
+  context "when sorting by most recently added" do
+    it "displays tags in the selected order" do
+      select "Most recently added", from: "search_order"
+      expect(page).to have_text(/#{tag_2.name}.+#{tag_3.name}.+#{tag_1.name}/m)
+    end
+  end
+
+  context "when sorting by least recently added" do
+    it "displays tags in the selected order" do
+      select "Least recently added", from: "search_order"
+      expect(page).to have_text(/#{tag_1.name}.+#{tag_3.name}.+#{tag_2.name}/m)
+    end
+  end
+
+  context "when sorting by highest number of taggings" do
+    it "displays tags in the selected order" do
+      select "Highest number of taggings", from: "search_order"
+      expect(page).to have_text(/#{tag_3.name}.+#{tag_1.name}.+#{tag_2.name}/m)
+    end
+  end
+
+  context "when sorting by lowest number of taggings" do
+    it "displays tags in the selected order" do
+      select "Lowest number of taggings", from: "search_order"
+      expect(page).to have_text(/#{tag_2.name}.+#{tag_1.name}.+#{tag_3.name}/m)
+    end
+  end
+end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?
N/A

### What Changed? And Why Did It Change?
This PR adds a search functionality to the Tags index. 

### How Has This Been Tested?
By hand and with system tests

### Please Provide Screenshots

https://github.com/user-attachments/assets/43e6b3d3-305e-4ef3-8390-839c185ad7a3



### Additional Comments
Currently, if we have a mix of tags starting with a capital letter and others starting with a lowercase letter, the lower-cased tags will be displayed at the end. I considered changing the sorting, but I think it would probably be better to fix the tags' names to make them consistent and ensure consistent capitalisation when we save the tags. Let me know what you think
