### PR TITLE
fix: disable gssencmode on darwin platform

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -27,9 +27,11 @@ development:
   primary:
     <<: *default
     database: skillrx_development
+    <% if RUBY_PLATFORM =~ /darwin/ %>gssencmode: disable<% end %>
   queue:
     <<: *default
     database: skillrx_development_queue
+    <% if RUBY_PLATFORM =~ /darwin/ %>gssencmode: disable<% end %>
     migrations_paths: db/queue_migrate
 
   # The specified database role being used to connect to PostgreSQL.
@@ -65,10 +67,12 @@ development:
 test:
   primary:
     <<: *default
+    <% if RUBY_PLATFORM =~ /darwin/ %>gssencmode: disable<% end %>
     database: skillrx_test
   queue:
     <<: *default
     database: skillrx_test_queue
+    <% if RUBY_PLATFORM =~ /darwin/ %>gssencmode: disable<% end %>
     migrations_paths: db/queue_migrate
 
 # As with config/credentials.yml, you never want to store sensitive information,


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

This PR contains workaround for issue with SEGV fault in `pg` gem working with `solid_queue`.
Issue was described and discussed here: https://github.com/rails/solid_queue/issues/492

### What Changed? And Why Did It Change?

Added settings for DB config specific for Darwin platform

### How Has This Been Tested?

Run `bin/server` and see no crash reports

### Please Provide Screenshots

### Additional Comments

We may want to change `solid_queue` config later, but no guarantees that it will help.
So adding this fix for now
