### PR TITLE
Order Tag dropdowns alphabetically

### DIFF
--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -32,7 +32,7 @@ module Taggable
   def available_tags
     return [] if language_tag_context.nil?
 
-    ActsAsTaggableOn::Tag.for_context(language_tag_context)
+    ActsAsTaggableOn::Tag.for_context(language_tag_context)&.order(name: :asc)
   end
 
   # Retrieves associated tags for the current language context

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -66,7 +66,7 @@ class Tag < ActsAsTaggableOn::Tag
   #
   # @return [ActiveRecord::Relation] collection of Tag records excluding self
   def all_available_tags
-    Tag.where.not(id: id)
+    Tag.where.not(id: [ id, cognates.ids, reverse_cognates.ids ].flatten).order(name: :asc)
   end
 
   private

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -123,12 +123,18 @@ RSpec.describe Tag, type: :model do
   end
 
   describe ".all_available_tags" do
-    it "returns all tags that are not cognates of the given tag" do
-      cognate_tag = create(:tag)
-      create(:tag_cognate, tag: subject, cognate: cognate_tag)
+    let!(:available_tag_1) { create(:tag, name: "zika") }
+    let!(:available_tag_2) { create(:tag, name: "cardiology") }
+    let(:reverse_cognate_tag) { create(:tag) }
+    let(:cognate_tag) { create(:tag) }
 
-      expect(subject.all_available_tags).to include(cognate_tag)
-      expect(subject.all_available_tags).not_to include(subject)
+    before do
+      create(:tag_cognate, tag: subject, cognate: cognate_tag)
+      create(:tag_cognate, tag: reverse_cognate_tag, cognate: subject)
+    end
+
+    it "returns all tags that are not cognates of the given tag" do
+      expect(subject.all_available_tags).to eq([ available_tag_2, available_tag_1 ])
     end
   end
 end

--- a/spec/services/xml_generator/all_providers_spec.rb
+++ b/spec/services/xml_generator/all_providers_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe XmlGenerator::AllProviders do
   let(:provider2) { create(:provider) }
   let!(:topic1) { create(:topic, :tagged, language:, provider: provider1) }
   let!(:topic2) { create(:topic, :tagged, language:, provider: provider2) }
+  let(:tag_topic1) { create(:tag, name: "flu") }
+  let(:tag_topic2) { create(:tag, name: "diabetes") }
+
+  before do
+    topic1.set_tag_list_on(topic1.language.code.to_sym, tag_topic1.name)
+    topic1.save
+    topic2.set_tag_list_on(topic2.language.code.to_sym, tag_topic1.name)
+    topic2.save
+  end
 
   it "generates the xml" do
     expect(subject.perform).to eq(

--- a/spec/support/taggable.rb
+++ b/spec/support/taggable.rb
@@ -28,7 +28,9 @@ RSpec.shared_examples "taggable" do
 
     describe "#available_tags" do
       it "delegates to ActsAsTaggableOn::Tag with correct context" do
-        expect(ActsAsTaggableOn::Tag).to receive(:for_context).with(:en)
+        tag_collection = double("tag_collection")
+        expect(ActsAsTaggableOn::Tag).to receive(:for_context).with(:en).and_return(tag_collection)
+        expect(tag_collection).to receive(:order).with(name: :asc)
         instance.available_tags
       end
     end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?
Not an Issue, just something I noticed while looking into Tags.

### What Changed? And Why Did It Change?
It orders Tags alphabetically in Tag dropdown menus and fixes a flaky test.

### How Has This Been Tested?
By hand and with RSpec

### Please Provide Screenshots
Before:
![Capture d'écran 2025-07-03 225535](https://github.com/user-attachments/assets/95dfe3c4-92c9-45c2-8c2b-980c2d926a92)
![Capture d'écran 2025-07-03 225551](https://github.com/user-attachments/assets/d86c6a47-7aa5-41c5-b980-c41c456e8ba8)


After:

![Capture d'écran 2025-07-03 223002](https://github.com/user-attachments/assets/f7827cf6-7e9d-4215-869c-9511f44db9b9)
![Capture d'écran 2025-07-03 222911](https://github.com/user-attachments/assets/42993c02-579d-49c7-9954-0eca0bb855ab)
