### PR TITLE
Fix cognates association bug when editing tags

### DIFF
--- a/app/models/tag_cognate.rb
+++ b/app/models/tag_cognate.rb
@@ -25,10 +25,17 @@ class TagCognate < ApplicationRecord
 
   validates :tag_id, uniqueness: { scope: :cognate_id }
   validate :no_self_reference
+  validate :no_similar_reverse_tag_cognate
 
   private
 
   def no_self_reference
     errors.add(:base, "Tag can't be its own cognate") if tag_id == cognate_id
+  end
+
+  def no_similar_reverse_tag_cognate
+    if TagCognate.where(tag_id: cognate_id, cognate_id: tag_id).exists?
+      errors.add(:base, "This cognate relationship already exists in reverse")
+    end
   end
 end

--- a/spec/models/tag_cognate_spec.rb
+++ b/spec/models/tag_cognate_spec.rb
@@ -42,5 +42,15 @@ RSpec.describe TagCognate, type: :model do
       expect(tag_cognate).not_to be_valid
       expect(tag_cognate.errors[:base]).to include("Tag can't be its own cognate")
     end
+
+    context "when a reverse TagCognate with the same Tag/Cognate combination already exists" do
+      let!(:reverse_tag_cognate) { create(:tag_cognate, tag: cognate, cognate: tag) }
+      let(:tag_cognate) { build(:tag_cognate, tag: tag, cognate: cognate) }
+
+      it "prevents creation of duplicate TagCognate" do
+        expect(tag_cognate).not_to be_valid
+        expect(tag_cognate.errors[:base]).to include("This cognate relationship already exists in reverse")
+      end
+    end
   end
 end

--- a/spec/requests/tags/update_spec.rb
+++ b/spec/requests/tags/update_spec.rb
@@ -37,6 +37,31 @@ describe "Tag", type: :request do
       end
     end
 
+    context "when adding a cognate on a tag that already had a cognate" do
+      let(:cardio_tag) { create(:tag, name: "Cardio") }
+      let(:cardiovascular_tag) { create(:tag, name: "Cardiovascular") }
+      let(:cardiac_tag) { create(:tag, name: "Cardiac") }
+      let(:tag_params) { attributes_for(:tag, name: "Heart", cognates_list: [ "", "Cardio", "Cardiovascular", "Cardiac" ]) }
+
+      before do
+        create(:tag_cognate, tag: tag, cognate: cardio_tag)
+        create(:tag_cognate, tag: cardio_tag, cognate: cardiovascular_tag)
+        create(:tag_cognate, tag: cardiovascular_tag, cognate: tag)
+      end
+
+      it "associates the new cognate to the tag and the old cognate" do
+        expect { put tag_url(tag), params: { tag: tag_params } }
+          .to change { tag.reload.cognates_list }
+          .from([ "Cardio", "Cardiovascular" ]).to(match_array([ "Cardio", "Cardiovascular", "Cardiac" ]))
+          .and change { cardiac_tag.reload.cognates_list }
+          .from([]).to(match_array([ "Heart", "Cardio", "Cardiovascular" ]))
+          .and change { cardiovascular_tag.reload.cognates_list }
+          .from([ "Hart", "Cardio" ]).to(match_array([ "Heart", "Cardio", "Cardiac" ]))
+          .and change { cardio_tag.reload.cognates_list }
+          .from([ "Hart", "Cardiovascular" ]).to(match_array([ "Heart", "Cardiovascular", "Cardiac" ]))
+      end
+    end
+
     context "when adding as cognate a tag that already has a cognate" do
       let(:cardiovascular_tag) { create(:tag, name: "Cardiovascular") }
       let(:cardio_tag) { create(:tag, name: "Cardio") }


### PR DESCRIPTION
### What Issue Does This PR Cover, If Any?
N/A, just something I noticed while looking into Tags.

### What Changed? And Why Did It Change?
It resolves 2 issues: 

- We were able to create a TagCognate with the reverse combination of Tag and Cognate of a pre-existing TagCognate, which is unnecessary duplication
- When adding a Cognate on a Tag that already had a Cognate, the associations ended up out of sync. For example, when adding Cognate C to Tag A which already had Tab B as a Cognate, we ended up with this:

Tag A: B, C
Tag B: A
Tag C: A

### How Has This Been Tested?
With RSpec and by hand

### Please Provide Screenshots
N/A

### Additional Comments
PR #233 will need to be merged first if you want to test this by hand including removing Tags, as #233 fixes an issue that prevents the current cognates from being selected on the Tag edit form
