### PR TITLE
Omit pre-2020 and pre-id-6110

### DIFF
--- a/app/controllers/import_reports_controller.rb
+++ b/app/controllers/import_reports_controller.rb
@@ -11,7 +11,7 @@ class ImportReportsController < ApplicationController
 
     # Collect unique statuses and import types for filter dropdowns
     @available_statuses = ImportReport.statuses.keys
-    @available_import_types = scope.distinct.pluck(:import_type).compact.sort
+    @available_import_types = scope.unscope(:order).distinct.pluck(:import_type).compact.sort
   end
 
   def show
@@ -25,6 +25,6 @@ class ImportReportsController < ApplicationController
   end
 
   def scope
-    @scope ||= ImportReport.all
+    @scope ||= ImportReport.order(completed_at: :desc)
   end
 end

--- a/app/models/import_report.rb
+++ b/app/models/import_report.rb
@@ -24,6 +24,6 @@ class ImportReport < ApplicationRecord
 
   enum :status, { pending: "pending", planned: "planned", completed: "completed", failed: "failed" }
 
-  scope :recent, -> { order(created_at: :desc) }
+  scope :recent, -> { order(status: :asc, created_at: :desc) }
   scope :by_type, ->(type) { where(import_type: type) }
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -30,7 +30,7 @@ class Topic < ApplicationRecord
 
   belongs_to :language
   belongs_to :provider
-  has_many_attached :documents
+  has_many_attached :documents, dependent: :purge
 
   validates :title, :language_id, :provider_id, :published_at, presence: true
   validates :documents, content_type: CONTENT_TYPES, size: { less_than: 200.megabytes }


### PR DESCRIPTION
We're omitting topics from before 2020. This also means we're leaving out any files associated with a topic_id before 6110.

Since we're omitting these, we now pass the filtered csv list to the report. The omitted files show up as being present in Azure but not in the CSV. This seems like a reasonable side effect.