### PR TITLE
Add/remove cognates when tagging or untagging Topics

### DIFF
--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -87,7 +87,7 @@ module Taggable
 
     Rails.logger.info "Processing tags: #{tag_list} for record: #{id}"
     removed_tags = current_tags_list - tag_list
-    cognates_names_for(tag_list + removed_tags)
+    @full_list_of_tags = tag_list + removed_tags
     tag_list_without_redundant_cognates = tag_list - tags_with_cognates(removed_tags)
     tag_list_with_cognates_to_add = tag_list_without_redundant_cognates + tags_with_cognates(tag_list_without_redundant_cognates)
     final_tag_list = tag_list_with_cognates_to_add.uniq.compact_blank.join(",")
@@ -96,12 +96,18 @@ module Taggable
   end
 
   def cognates_names_for(tags_to_keep_add_or_remove)
-    @tag_cognates_map ||= Tag.where(name: tags_to_keep_add_or_remove).each_with_object({}) do |tag, hash|
+    Tag.where(name: tags_to_keep_add_or_remove).each_with_object({}) do |tag, hash|
       hash[tag.name] = tag.cognates_tags.for_context(language.code.to_sym).uniq.pluck(:name).push(tag.name)
     end
   end
 
   def tags_with_cognates(list)
-    @tag_cognates_map.slice(*list).values.flatten
+    tag_cognates_map.slice(*list).values.flatten
   end
+
+  def tag_cognates_map
+    @tag_cognates_map ||= cognates_names_for(full_list_of_tags)
+  end
+
+  attr_reader :full_list_of_tags
 end

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -42,6 +42,7 @@
               <%= f.label :tag_list, class: "flex-fill" %>
               <small class="flex-fill text-end fw-light text-muted text-uppercase">Press enter to add a new tag</small>
             </div>
+            <p>Please note: For any tag you add or remove, its cognates are also added or removed.</p>
             <%= f.select :tag_list,
                          options_from_collection_for_select(
                            topic.available_tags,

--- a/spec/requests/tags/update_spec.rb
+++ b/spec/requests/tags/update_spec.rb
@@ -125,7 +125,7 @@ describe "Tag", type: :request do
       it "removes the associations with the removed cognates" do
         expect { put tag_url(tag), params: { tag: tag_params } }
           .to change { tag.reload.cognates_list }
-          .from([ "Cardiovascular", "Cardio" ]).to([])
+          .from(match_array([ "Cardiovascular", "Cardio" ])).to([])
 
         cardiovascular_tag = Tag.find_by(name: "Cardiovascular")
         cardio_tag = Tag.find_by(name: "Cardio")

--- a/spec/requests/topics/update_spec.rb
+++ b/spec/requests/topics/update_spec.rb
@@ -61,22 +61,23 @@ RSpec.describe "Topics", type: :request do
     end
 
     context "when removing a tag whose cognate remains associated to the Topic" do
-      let!(:tag) { create(:tag, name: "Tag to remove") }
-      let!(:cognate) { create(:tag, name: "Cognate to keep") }
-      let(:topic_params) {  { tag_list: [ cognate.name ] } }
+      let!(:tag) { create(:tag, name: "tag") }
+      let!(:cognate) { create(:tag, name: "cognate") }
+      let(:topic_params) {  { tag_list: [ "cognate" ] } }
 
       before do
         tag.cognates << cognate
-        topic.set_tag_list_on(topic.language.code.to_sym, "#{tag.name},#{cognate.name}")
+        topic.set_tag_list_on(topic.language.code.to_sym, "tag,cognate")
         topic.save
       end
 
-      it "removes the tag but keeps the cognate" do
+      it "removes the tag and the cognate" do
         put topic_url(topic), params: { topic: topic_params }
 
         expect(response).to redirect_to(topics_url)
-        expect(topic.reload.current_tags).to eq([ cognate ])
-        expect(Tag.find_by(name: tag.name)).to be_nil
+        expect(topic.reload.current_tags).to eq([])
+        expect(Tag.find_by(name: "tag")).to be_nil
+        expect(Tag.find_by(name: "cognate")).to be_nil
       end
     end
 

--- a/spec/services/xml_generator/single_provider_spec.rb
+++ b/spec/services/xml_generator/single_provider_spec.rb
@@ -17,7 +17,14 @@ RSpec.describe XmlGenerator::SingleProvider do
   end
 
   context "with topics" do
-    let!(:topic) { create(:topic, :tagged, :with_documents, provider:) }
+    let!(:topic) { create(:topic, :with_documents, provider:) }
+    let(:tag_1) { create(:tag, name: "iddm") }
+    let(:tag_2) { create(:tag, name: "diabetes") }
+
+  before do
+    topic.set_tag_list_on(topic.language.code.to_sym, "#{tag_1.name},#{tag_2.name}")
+    topic.save
+  end
 
     it "generates the xml" do
       expect(subject.perform).to eq(

--- a/spec/support/taggable.rb
+++ b/spec/support/taggable.rb
@@ -88,6 +88,7 @@ RSpec.shared_examples "taggable" do
         tag1 = create(:tag, name: tag_list.first)
         create(:tag_cognate, tag: tag1, cognate: cognate)
         create(:tag_cognate, tag: reverse_cognate, cognate: tag1)
+        create(:tag_cognate, tag: reverse_cognate, cognate: cognate)
         tags_and_their_cognates = tag_list.push(cognate.name, reverse_cognate.name)
         instance.set_tag_list_on(instance.language.code.to_sym, tags_and_their_cognates)
         instance.save

--- a/spec/support/taggable.rb
+++ b/spec/support/taggable.rb
@@ -1,56 +1,56 @@
 RSpec.shared_examples "taggable" do
-    let(:model) { described_class }
-    let(:language) { create(:language, name: "English") }
-    let(:instance) { create(model.to_s.underscore.to_sym, language: language) }
+  let(:model) { described_class }
+  let(:language) { create(:language, name: "English") }
+  let(:instance) { create(model.to_s.underscore.to_sym, language: language) }
 
-    describe "module inclusion" do
-      it "includes required modules" do
-        expect(model.included_modules).to include(Taggable)
+  describe "module inclusion" do
+    it "includes required modules" do
+      expect(model.included_modules).to include(Taggable)
+    end
+  end
+
+  describe "#language_tag_context" do
+    context "when language is present" do
+      it "returns language iso code as symbol" do
+        expect(instance.language_tag_context).to eq(:en)
       end
     end
 
-    describe "#language_tag_context" do
-      context "when language is present" do
-        it "returns language iso code as symbol" do
-          expect(instance.language_tag_context).to eq(:en)
-        end
-      end
+    context "when language is nil" do
+      before { instance.language = nil }
 
-      context "when language is nil" do
-        before { instance.language = nil }
-
-        it "raises LanguageContextError" do
-          expect { instance.language_tag_context }
-            .to raise_error(Taggable::LanguageContextError, "Language must be present")
-        end
+      it "raises LanguageContextError" do
+        expect { instance.language_tag_context }
+          .to raise_error(Taggable::LanguageContextError, "Language must be present")
       end
     end
+  end
 
-    describe "#available_tags" do
-      it "delegates to ActsAsTaggableOn::Tag with correct context" do
-        tag_collection = double("tag_collection")
-        expect(ActsAsTaggableOn::Tag).to receive(:for_context).with(:en).and_return(tag_collection)
-        expect(tag_collection).to receive(:order).with(name: :asc)
-        instance.available_tags
-      end
+  describe "#available_tags" do
+    it "delegates to ActsAsTaggableOn::Tag with correct context" do
+      tag_collection = double("tag_collection")
+      expect(ActsAsTaggableOn::Tag).to receive(:for_context).with(:en).and_return(tag_collection)
+      expect(tag_collection).to receive(:order).with(name: :asc)
+      instance.available_tags
     end
+  end
 
-    describe "#current_tags_list" do
-      it "returns tags for the language context" do
-        expect(instance).to receive(:tag_list_on).with(:en)
-        instance.current_tags_list
-      end
+  describe "#current_tags_list" do
+    it "returns tags for the language context" do
+      expect(instance).to receive(:tag_list_on).with(:en)
+      instance.current_tags_list
     end
+  end
 
-    describe "#save_with_tags" do
-      it "processes tags correctly" do
-        tag_list = [ "test", "tags" ]
-        attrs = { title: "New Title", tag_list: tag_list }
+  describe "#save_with_tags" do
+    it "processes tags correctly" do
+      tag_list = [ "test", "tags" ]
+      attrs = { title: "New Title", tag_list: tag_list }
 
-        expect(instance).to receive(:update).with({ title: "New Title" }).and_return(true)
-        expect(instance).to receive(:process_tags).with(tag_list)
+      expect(instance).to receive(:update).with({ title: "New Title" }).and_return(true)
+      expect(instance).to receive(:process_tags).with(tag_list)
 
-        instance.save_with_tags(attrs)
-      end
+      instance.save_with_tags(attrs)
     end
+  end
 end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

It solves an issue discussed with @dcollie2 on Slack: we set up Tags to have Cognates, but we didn't make use of these Cognates until now.

### What Changed? And Why Did It Change?
Now, when users add a Tag on a Topic, that Tag's cognates are also added to the Topic.
Inversely, when a Tag is removed from a Topic, that Tag's cognates are also removed from the Topic.

### How Has This Been Tested?
With RSpec and by hand

### Please Provide Screenshots


https://github.com/user-attachments/assets/95451708-571a-4be9-9ef9-b48b1a96d8a2



https://github.com/user-attachments/assets/a5708a78-8b01-4360-918c-10f3f96b89dc



### Additional Comments
I'll follow up by adding a job to sync cognates on Topics when an Admin adds/remove cognates from a Tag.