### PR TITLE
Fix topics pagination

### DIFF
--- a/app/views/topics/_list.html.erb
+++ b/app/views/topics/_list.html.erb
@@ -7,7 +7,7 @@
       <td class="text-bold-500"><%= topic.language.name %></td>
       <td class="text-bold-500"><%= topic.provider.name %></td>
       <td class="text-bold-500"><%= topic.documents.size %></td>
-      <td class="text-bold-500"><%= topic.state %></td>
+      <td class="text-bold-500"><span class="badge <%= topic.state == "active" ? "bg-success" : "bg-light-danger" %>"><%= topic.state %></span></td>
       <td class="text-end">
         <%= link_to topic, class: "btn btn-primary btn-sm", data: {turbo: false } do %>
           <i class="bi bi-search"></i> View

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -36,11 +36,11 @@
                     <%= render "list", topics: @topics %>
                   </table>
                 </div>
+                <div class="card-footer d-flex justify-content-end">
+                  <%== pagy_bootstrap_nav(@pagy) %>
+                </div>
               <% end %>
             </div>
-          </div>
-          <div class="card-footer d-flex justify-content-end">
-            <%== pagy_bootstrap_nav(@pagy) %>
           </div>
         </div>
       <% end %>

--- a/spec/system/topics/pagination_spec.rb
+++ b/spec/system/topics/pagination_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Topics pagination", type: :system do
+  let(:english) { create(:language, name: "English") }
+  let(:provider) { create(:provider) }
+
+  before do
+    # Create enough topics to have multiple pages
+    40.times do |i|
+      create(:topic, :archived, language: english, title: "Archived Topic #{i}", provider: provider)
+    end
+    create(:topic, language: english, title: "Active Topic", provider: provider)
+
+    login_as(create(:user, :admin))
+    click_link("Topics")
+  end
+
+  it "preserves search filters when paginating" do
+    select "archived", from: "search_state"
+
+    # Ensure only archived topics are visible
+    expect(page).to have_text("Archived Topic", count: 20)
+    expect(page).not_to have_text("Active Topic")
+
+    click_link("Next")
+
+    expect(page).to have_text("Archived Topic", count: 20)
+    expect(page).not_to have_text("Active Topic")
+    expect(page.current_url).to include("search%5Bstate%5D=archived")
+  end
+end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #249 

### What Changed? And Why Did It Change?
- Add a badge to the topics list to visually indicate the state of each topic.
- Fix a bug in the pagination where the filter parameters were not preserved when navigating between pages.

### How Has This Been Tested?
- There is a system spec in place

### Please Provide Screenshots
https://github.com/user-attachments/assets/12cbc450-4a34-409b-bfb6-0067ea8fcfb8
