### PR TITLE
Reflect cognates on Topics when Tag gets a new cognates

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -16,6 +16,7 @@ class TagsController < ApplicationController
 
   def update
     if @tag.update!(tag_params)
+      SynchronizeCognatesOnTopicsJob.perform_later(@tag) if tag_params[:cognates_list].reject(&:empty?).any?
       redirect_to tags_path, notice: "Tag was successfully updated."
     else
       render :edit, status: :unprocessable_entity

--- a/app/jobs/synchronize_cognates_on_topics_job.rb
+++ b/app/jobs/synchronize_cognates_on_topics_job.rb
@@ -1,0 +1,9 @@
+class SynchronizeCognatesOnTopicsJob < ApplicationJob
+  def perform(tag)
+    Topic.where(id: tag.taggings.select(:taggable_id)).each do |topic|
+      tags = topic.current_tags_list << tag.cognates_tags.for_context(topic.language_code).uniq.pluck(:name)
+      topic.set_tag_list_on(topic.language_code, tags)
+      topic.save
+    end
+  end
+end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -23,7 +23,7 @@ module Taggable
     raise LanguageContextError, "Language must be present" if language.nil?
     raise LanguageContextError, "Language code must be present" if language.code.blank?
 
-    language.code.to_sym
+    language_code
   end
 
   # Retrieves all available tags for the current language context
@@ -61,7 +61,11 @@ module Taggable
 
     language = Language.find(language_id)
 
-    tags_on(language.code.to_sym)
+    tags_on(language_code)
+  end
+
+  def language_code
+    language.code.to_sym
   end
 
   # Updates the list of tags for a specific record
@@ -91,13 +95,13 @@ module Taggable
     tag_list_without_redundant_cognates = tag_list - tags_with_cognates(removed_tags)
     tag_list_with_cognates_to_add = tag_list_without_redundant_cognates + tags_with_cognates(tag_list_without_redundant_cognates)
     final_tag_list = tag_list_with_cognates_to_add.uniq.compact_blank.join(",")
-    set_tag_list_on(language.code.to_sym, final_tag_list)
+    set_tag_list_on(language_code, final_tag_list)
     save!
   end
 
   def cognates_names_for(tags_to_keep_add_or_remove)
     Tag.where(name: tags_to_keep_add_or_remove).each_with_object({}) do |tag, hash|
-      hash[tag.name] = tag.cognates_tags.for_context(language.code.to_sym).uniq.pluck(:name).push(tag.name)
+      hash[tag.name] = tag.cognates_tags.for_context(language_code).uniq.pluck(:name).push(tag.name)
     end
   end
 

--- a/lib/autorequire/data_import.rb
+++ b/lib/autorequire/data_import.rb
@@ -192,7 +192,7 @@ class DataImport
       end.join(",")
 
       # Set the topic tags in the pertinent context (language comes from the topic's language)
-      topic.set_tag_list_on(topic.language.code.to_sym, tag_names_str)
+      topic.set_tag_list_on(topic.language_code, tag_names_str)
       topic.save!
 
       puts "#{topic.title} - #{topic.id} / Tags: #{topic.current_tags_list}"

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
     trait :tagged do
       after(:create) do |topic|
         tag = build(:tag)
-        topic.set_tag_list_on(topic.language.code.to_sym, tag.name)
+        topic.set_tag_list_on(topic.language_code, tag.name)
         topic.save
       end
     end

--- a/spec/jobs/synchronize_cognates_on_topics_job_spec.rb
+++ b/spec/jobs/synchronize_cognates_on_topics_job_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe SynchronizeCognatesOnTopicsJob, type: :job do
+  let(:english) { create(:language, name: "english") }
+  let(:spanish) { create(:language, name: "spanish") }
+  let(:english_topic_1) { create(:topic, language: english) }
+  let(:english_topic_2) { create(:topic, language: english) }
+  let(:spanish_topic_1) { create(:topic, language: spanish) }
+  let!(:tag) { create(:tag, name: "tag") }
+  let!(:english_cognate) { create(:tag, name: "english cognate") }
+  let!(:english_reverse_cognate) { create(:tag, name: "english reverse cognate") }
+  let!(:spanish_cognate) { create(:tag, name: "spanish cognate") }
+  let!(:spanish_reverse_cognate) { create(:tag, name: "spanish reverse cognate") }
+
+  before do
+    spanish_topic_1.set_tag_list_on(:sp, "spanish cognate,spanish reverse cognate")
+    spanish_topic_1.save
+    english_topic_2.set_tag_list_on(:en, "english cognate,english reverse cognate")
+    english_topic_2.save
+  end
+
+  context "when adding cognates to a tag" do
+    before do
+      english_topic_1.set_tag_list_on(:en, "tag")
+      english_topic_1.save
+      create(:tag_cognate, tag: tag, cognate: english_cognate)
+      create(:tag_cognate, tag: english_reverse_cognate, cognate: tag)
+      create(:tag_cognate, tag: english_reverse_cognate, cognate: english_cognate)
+      create(:tag_cognate, tag: tag, cognate: spanish_cognate)
+      create(:tag_cognate, tag: spanish_reverse_cognate, cognate: tag)
+      create(:tag_cognate, tag: spanish_reverse_cognate, cognate: spanish_cognate)
+    end
+
+    it "adds new cognates to topics tagged with the original tag" do
+      SynchronizeCognatesOnTopicsJob.perform_now(tag)
+      expect(Topic.find_by(id: english_topic_1.id).current_tags_list)
+        .to match_array([ "tag", "english cognate", "english reverse cognate" ])
+    end
+  end
+end

--- a/spec/requests/tags/api/v1/index_spec.rb
+++ b/spec/requests/tags/api/v1/index_spec.rb
@@ -30,7 +30,7 @@ describe "Tags", type: :request do
   private
 
   def tag_topic(topic, tag)
-    topic.set_tag_list_on(topic.language.code.to_sym, tag.name)
+    topic.set_tag_list_on(topic.language_code, tag.name)
     topic.save
   end
 end

--- a/spec/requests/tags/update_spec.rb
+++ b/spec/requests/tags/update_spec.rb
@@ -22,6 +22,11 @@ describe "Tag", type: :request do
       expect(cardio_tag.cognates_list).to match_array([ "Heart", "Cardiovascular" ])
     end
 
+    it "enqueues SynchronizeCognatesOnTopicsJob" do
+      put tag_url(tag), params: { tag: tag_params }
+      expect(SynchronizeCognatesOnTopicsJob).to have_been_enqueued.with(tag)
+    end
+
     context "when the same tag is passed twice as cognate" do
       let(:tag_params) { attributes_for(:tag, name: "Heart", cognates_list: [ "", "Heart", "Cardiovascular", "Cardio", "Cardio" ]) }
 
@@ -133,6 +138,11 @@ describe "Tag", type: :request do
         expect(cardiovascular_tag.cognates_list).to be_empty
         expect(cardio_tag).not_to be_nil
         expect(cardio_tag.cognates_list).to be_empty
+      end
+
+      it "does not enqueue SynchronizeCognatesOnTopicsJob" do
+        put tag_url(tag), params: { tag: tag_params }
+        expect(SynchronizeCognatesOnTopicsJob).not_to have_been_enqueued.with(tag)
       end
     end
   end

--- a/spec/requests/tags/update_spec.rb
+++ b/spec/requests/tags/update_spec.rb
@@ -57,13 +57,13 @@ describe "Tag", type: :request do
       it "associates the new cognate to the tag and the old cognate" do
         expect { put tag_url(tag), params: { tag: tag_params } }
           .to change { tag.reload.cognates_list }
-          .from([ "Cardio", "Cardiovascular" ]).to(match_array([ "Cardio", "Cardiovascular", "Cardiac" ]))
+          .from(match_array([ "Cardio", "Cardiovascular" ])).to(match_array([ "Cardio", "Cardiovascular", "Cardiac" ]))
           .and change { cardiac_tag.reload.cognates_list }
           .from([]).to(match_array([ "Heart", "Cardio", "Cardiovascular" ]))
           .and change { cardiovascular_tag.reload.cognates_list }
-          .from([ "Hart", "Cardio" ]).to(match_array([ "Heart", "Cardio", "Cardiac" ]))
+          .from(match_array([ "Hart", "Cardio" ])).to(match_array([ "Heart", "Cardio", "Cardiac" ]))
           .and change { cardio_tag.reload.cognates_list }
-          .from([ "Hart", "Cardiovascular" ]).to(match_array([ "Heart", "Cardiovascular", "Cardiac" ]))
+          .from(match_array([ "Hart", "Cardiovascular" ])).to(match_array([ "Heart", "Cardiovascular", "Cardiac" ]))
       end
     end
 
@@ -103,7 +103,7 @@ describe "Tag", type: :request do
       it "removes the association to the removed cognates" do
         expect { put tag_url(tag), params: { tag: tag_params } }
           .to change { tag.reload.cognates_list }
-          .from([ "Cardiovascular", "Cardio", "Circulatory" ]).to([ "Cardio" ])
+          .from(match_array([ "Cardiovascular", "Cardio", "Circulatory" ])).to([ "Cardio" ])
 
         cardiovascular_tag = Tag.find_by(name: "Cardiovascular")
         cardio_tag = Tag.find_by(name: "Cardio")

--- a/spec/requests/topics/update_spec.rb
+++ b/spec/requests/topics/update_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Topics", type: :request do
       let!(:tag) { create(:tag, name: "Tag to remove") }
 
       before do
-        topic.set_tag_list_on(topic.language.code.to_sym, tag.name)
+        topic.set_tag_list_on(topic.language_code, tag.name)
         topic.save
       end
 
@@ -47,7 +47,7 @@ RSpec.describe "Topics", type: :request do
         let(:topic_params) {  { tag_list: [ "" ] } }
 
         before do
-          topic_2.set_tag_list_on(topic.language.code.to_sym, tag.name)
+          topic_2.set_tag_list_on(topic.language_code, tag.name)
           topic_2.save
         end
 
@@ -67,7 +67,7 @@ RSpec.describe "Topics", type: :request do
 
       before do
         tag.cognates << cognate
-        topic.set_tag_list_on(topic.language.code.to_sym, "tag,cognate")
+        topic.set_tag_list_on(topic.language_code, "tag,cognate")
         topic.save
       end
 

--- a/spec/services/csv_generator/tag_details_spec.rb
+++ b/spec/services/csv_generator/tag_details_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CsvGenerator::TagDetails do
       before do
         topic.tags_on(language.code.to_sym).each do |t|
           tag = build(:tag, name: t.name)
-          second_topic.set_tag_list_on(topic.language.code.to_sym, tag.name)
+          second_topic.set_tag_list_on(topic.language_code, tag.name)
           second_topic.save
         end
       end

--- a/spec/services/xml_generator/all_providers_spec.rb
+++ b/spec/services/xml_generator/all_providers_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe XmlGenerator::AllProviders do
   let(:tag_topic2) { create(:tag, name: "diabetes") }
 
   before do
-    topic1.set_tag_list_on(topic1.language.code.to_sym, tag_topic1.name)
+    topic1.set_tag_list_on(topic1.language_code, tag_topic1.name)
     topic1.save
-    topic2.set_tag_list_on(topic2.language.code.to_sym, tag_topic1.name)
+    topic2.set_tag_list_on(topic2.language_code, tag_topic1.name)
     topic2.save
   end
 

--- a/spec/services/xml_generator/single_provider_spec.rb
+++ b/spec/services/xml_generator/single_provider_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe XmlGenerator::SingleProvider do
     before do
       topic.set_tag_list_on(topic.language.code.to_sym, "#{tag_1.name},#{tag_2.name}")
       topic.save
-      topic.documents.attach(document.signed_id) # we need only to attach viodeo file to topic, saving here is redundant
+      topic.documents.attach(document.signed_id) # we need only to attach video file to topic, saving here is redundant
     end
 
     it "generates the xml" do

--- a/spec/support/taggable.rb
+++ b/spec/support/taggable.rb
@@ -42,6 +42,12 @@ RSpec.shared_examples "taggable" do
     end
   end
 
+  describe "#language_code" do
+    it "returns the instance's language code as a symbol" do
+      expect(instance.language_code).to eq(:en)
+    end
+  end
+
   describe "#save_with_tags" do
     let(:tag_list) { [ "malaria", "fever" ] }
     let(:attrs) { { title: "New Title", tag_list: tag_list } }
@@ -90,7 +96,7 @@ RSpec.shared_examples "taggable" do
         create(:tag_cognate, tag: reverse_cognate, cognate: tag1)
         create(:tag_cognate, tag: reverse_cognate, cognate: cognate)
         tags_and_their_cognates = tag_list.push(cognate.name, reverse_cognate.name)
-        instance.set_tag_list_on(instance.language.code.to_sym, tags_and_their_cognates)
+        instance.set_tag_list_on(instance.language_code, tags_and_their_cognates)
         instance.save
       end
 


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Follow-up to https://github.com/rubyforgood/skillrx/pull/254, discussed during the call on 12 July, 2025

### What Changed? And Why Did It Change?
Currently, when users tag a Topic, we automatically tag that Topic with that Tag's cognates.

This PR introduces a job to make sure that we also tag Topic with any relevant cognates when an Admin adds a cognate to a Tag.

I haven't done anything for when an Admin removes a cognate from a Tag as I think the removed cognate might still be relevant to the Topic, even if it is no longer as a cognate.

I also added a language_code on Taggable so we don't have to type language.code.to_sym every time.

### How Has This Been Tested?
With RSpec and by hand

### Please Provide Screenshots

https://github.com/user-attachments/assets/75f654c1-de77-4f6c-a670-5f92e7da623f

