### PR TITLE
update azure_file_shares gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/dmitrytrager/azure_file_shares.git
-  revision: c27cc7bcdb6be0ae382f7665158262d9936c2eed
+  revision: 657860586bf58167c0d848381cdbe5cda4784c3e
   specs:
-    azure_file_shares (0.1.3)
+    azure_file_shares (0.1.4)
       faraday (~> 2.7)
       faraday-retry (~> 2.0)
       jwt (~> 2.7)

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -62,7 +62,7 @@
                   <%= link_to edit_user_path(user), class: "btn btn-secondary btn-sm pr-2" do %>
                     <i class="bi bi-pencil"></i> Edit
                   <% end %>
-                  <%= button_to  user, data: { confirm: "Are you sure?" }, method: :delete,form_class:"d-inline",  class: "btn btn-danger btn-sm " do %>
+                  <%= button_to user, data: { confirm: "Are you sure?" }, method: :delete, form_class:"d-inline", class: "btn btn-danger btn-sm" do %>
                     <i class="bi bi-trash"></i> Delete
                   <% end %>
                 </td>


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #262

### What Changed? And Why Did It Change?

Azure file shares gem was changed:
* it now uses different way to encode url params (including file names)
* spaces are maintained on Azure side as a result of this change

### How Has This Been Tested?

### Please Provide Screenshots

<img width="399" height="206" alt="Screenshot 2025-07-17 at 23 01 52" src="https://github.com/user-attachments/assets/51181d25-f11f-4325-bf41-879aef9c0a56" />
<img width="689" height="158" alt="Screenshot 2025-07-17 at 22 58 02" src="https://github.com/user-attachments/assets/ef27501f-ee4c-4102-a106-e96f5cf3b4bd" />


### Additional Comments
