### PR TITLE
Rename "Training Materials" to "# of Documents"

### DIFF
--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -28,7 +28,7 @@
                         <th>UID</th>
                         <th>Language</th>
                         <th>Provider</th>
-                        <th>Training<br>Materials</th>
+                        <th># of Documents</th>
                         <th>State</th>
                         <th class="text-end">Actions</th>
                       </tr>


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #276 <!--fill issue number-->

### What Changed? And Why Did It Change?
I changes a label on Topics index from "Training Materials" to "# of Documents"

### How Has This Been Tested?
N/A

### Please Provide
<img width="1524" height="249" alt="Renamed label on Topics index" src="https://github.com/user-attachments/assets/467f318c-ab48-40b2-b18d-8059816b12ac" />
 Screenshots

### Additional Comments
N/A