### PR TITLE
Scout explicit monitoring

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,6 +43,7 @@ Rails.application.configure do
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
   config.solid_queue.logger = ActiveSupport::Logger.new(STDOUT)
+  config.solid_queue.clear_finished_jobs_after = 1.month
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = ENV["DOCKER_CONTAINER"] == "true" ? :amazon : :local

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,6 +52,7 @@ Rails.application.configure do
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
+  config.solid_queue.clear_finished_jobs_after = 1.month
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -52,6 +52,7 @@ Rails.application.configure do
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
+  config.solid_queue.clear_finished_jobs_after = 5.days
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -3,6 +3,10 @@ default: &default
     command: LanguageFilesScheduler.new.perform
     queue: default
     schedule: "00 21 * * *" # Every day at 21
+  periodic_job_cleanup:
+    command: SolidQueue::Job.clear_finished_in_batches
+    queue: default
+    schedule: at 4pm every day
 
 development:
   <<: *default

--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -9,7 +9,7 @@ common: &defaults
   # log_level: Verboseness of logs.
   # - Default: 'info'
   # - Valid Options: debug, info, warn, error
-  # log_level: debug
+  log_level: debug
 
   # use_prepend: Use the newer `prepend` instrumentation method. In some cases, gems
   #              that use `alias_method` can conflict with gems that use `prepend`.
@@ -31,10 +31,12 @@ common: &defaults
   # monitor: Enable Scout APM or not
   # - Default: none
   # - Valid Options: true, false
-  monitor: true
+  # monitor: true
+  # Commented out to be specific per-environment below
 
 production:
   <<: *defaults
+  monitor: true
 
 development:
   <<: *defaults
@@ -46,3 +48,4 @@ test:
 
 staging:
   <<: *defaults
+  monitor: true


### PR DESCRIPTION
Sets scout monitoring explicitly as an attempt to get it working correctly in staging.

Adds recurring task to clear old solid queue jobs.