### PR TITLE
Add mission control

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "image_processing", "~> 1.14"
 gem "importmap-rails"
 gem "jbuilder"
 gem "kamal", require: false
+gem "mission_control-jobs"
 gem "pagy"
 gem "pg", "~> 1.1"
 gem "propshaft"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,16 @@ GEM
       logger
     mini_mime (1.1.5)
     minitest (5.25.5)
+    mission_control-jobs (1.1.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
     msgpack (1.8.0)
     net-http (0.6.0)
       uri
@@ -528,6 +538,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
+  mission_control-jobs
   pagy
   pg (~> 1.1)
   propshaft

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module Skillrx
     #
     # config.time_zone = "Central Time (US & Canada)"
     config.eager_load_paths << Rails.root.join("lib/autorequire")
+
+    config.mission_control.jobs.http_basic_auth_enabled = false
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ require "solid_queue_monitor"
 
 Rails.application.routes.draw do
   mount SolidQueueMonitor::Engine => "/solid_queue"
+  mount MissionControl::Jobs::Engine, at: "/jobs"
   resources :languages, only: %i[index show new create edit update]
   resources :passwords, param: :token
   resources :providers


### PR DESCRIPTION
This adds mission control with basic auth disabled so it can be seen by any logged-in user. We'll need to change that and remove solid-queue-monitor if we decide to stick with this.

