### PR TITLE
Add confirmation step before deleting topic

### DIFF
--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -14,7 +14,7 @@ class LanguagesController < ApplicationController
     @language = Language.new(language_params)
 
     if @language.save
-      redirect_to languages_path
+      redirect_to languages_path, notice: "Language was successfully created."
     else
       render :new
     end
@@ -25,7 +25,7 @@ class LanguagesController < ApplicationController
 
   def update
     @language.update(language_params)
-    redirect_to languages_path
+    redirect_to languages_path, notice: "Language was successfully updated."
   end
 
   private

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -46,8 +46,12 @@ class TopicsController < ApplicationController
   def destroy
     redirect_to topics_path and return unless Current.user.is_admin?
 
-    Topics::Mutator.new(topic: @topic).destroy
-    redirect_to topics_path
+    if params[:confirmed]
+      Topics::Mutator.new(topic: @topic).destroy
+      redirect_to topics_path, notice: "Topic was successfully destroyed."
+    else
+      respond_to { |format| format.turbo_stream }
+    end
   end
 
   def archive

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -19,7 +19,7 @@ class TopicsController < ApplicationController
 
     case mutator.create
     in [ :ok, _topic ]
-      redirect_to topics_path
+      redirect_to topics_path, notice: "Topic was successfully created."
     in [ :error, errors ]
       @errors = errors
       render :new, status: :unprocessable_entity
@@ -36,7 +36,7 @@ class TopicsController < ApplicationController
   def update
     case mutator.update
     in [ :ok, _topic ]
-      redirect_to topics_path
+      redirect_to topics_path, notice: "Topic was successfully updated."
     in [ :error, errors ]
       @errors = errors
       render :edit, status: :unprocessable_entity
@@ -56,12 +56,12 @@ class TopicsController < ApplicationController
 
   def archive
     Topics::Mutator.new(topic: @topic).archive
-    redirect_to topics_path
+    redirect_to topics_path, notice: "Topic was successfully archived."
   end
 
   def unarchive
     Topics::Mutator.new(topic: @topic).unarchive
-    redirect_to topics_path
+    redirect_to topics_path, notice: "Topic was successfully reinstated."
   end
 
   private

--- a/app/views/topics/destroy.turbo_stream.erb
+++ b/app/views/topics/destroy.turbo_stream.erb
@@ -1,0 +1,14 @@
+<%= turbo_stream.update "delete_topic_#{@topic.id}" do %>
+  <div class="confirmation-dialog mt-4">
+    <h5>Destroying a topic is permanent. Are you sure you want to delete this topic?</h5>
+
+    <div class="mt-4 hstack gap-3">
+      <div>
+        <%= button_to "Confirm Delete", topic_path(@topic, confirmed: true),  method: :delete, class: "btn btn-danger" %>
+      </div>
+      <div>
+        <%= link_to "Cancel", topic_path(@topic), class: "btn btn-secondary" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -18,7 +18,7 @@
 <% end %>
 
 <% if Current.user.is_admin? %>
-  <div>
+  <div id="delete_topic_<%= @topic.id %>">
     <%= button_to "Delete this topic", @topic, method: :delete, class: "btn btn-danger mt-4" %>
   </div>
 <% end %>

--- a/spec/requests/languages/create_spec.rb
+++ b/spec/requests/languages/create_spec.rb
@@ -14,5 +14,11 @@ describe "Languages", type: :request do
       expect(Language.last.name).to eq("french")
       expect(Language.last.file_storage_prefix).to eq("FR_")
     end
+
+    it "displays a success message" do
+      post languages_url, params: { language: language_params }
+
+      expect(flash[:notice]).to eq("Language was successfully created.")
+    end
   end
 end

--- a/spec/requests/languages/update_spec.rb
+++ b/spec/requests/languages/update_spec.rb
@@ -3,19 +3,24 @@ require "rails_helper"
 describe "Languages", type: :request do
   describe "PUT /languages" do
     let(:user) { create(:user, :admin) }
+    let(:language) { create(:language) }
+    let(:language_params) { { name: "french" } }
 
     before { sign_in(user) }
 
     it "updates a Language" do
-      language = create(:language)
-      language_params = { name: "french" }
-
       put language_url(language), params: { language: language_params }
 
       language.reload
       expect(response).to redirect_to(languages_path)
       expect(language.name).to eq("french")
       expect(language.file_storage_prefix).to eq("FR_")
+    end
+
+    it "displays a success message" do
+      put language_url(language), params: { language: language_params }
+
+      expect(flash[:notice]).to eq("Language was successfully updated.")
     end
   end
 end

--- a/spec/requests/topics/archive_spec.rb
+++ b/spec/requests/topics/archive_spec.rb
@@ -14,6 +14,12 @@ describe "Topics", type: :request do
       expect(topic.reload.state).to eq("archived")
     end
 
+    it "displays a success message" do
+      put archive_topic_url(topic)
+
+      expect(flash[:notice]).to eq("Topic was successfully archived.")
+    end
+
     context "when topic has documents" do
       let(:topic) { create(:topic, :with_documents) }
 

--- a/spec/requests/topics/create_spec.rb
+++ b/spec/requests/topics/create_spec.rb
@@ -28,7 +28,13 @@ describe "Topics", type: :request do
       expect(topic.state).to eq("active")
     end
 
-    context "when user is ad admin" do
+    it "displays a success message" do
+      post topics_url, params: { topic: topic_params }
+
+      expect(flash[:notice]).to eq("Topic was successfully created.")
+    end
+
+    context "when user is an admin" do
       let(:new_provider) { create(:provider) }
 
       before { user.update(is_admin: true) }

--- a/spec/requests/topics/destroy_spec.rb
+++ b/spec/requests/topics/destroy_spec.rb
@@ -3,15 +3,49 @@ require "rails_helper"
 describe "Topics", type: :request do
   describe "DELETE /topics/:id" do
     let(:user) { create(:user, :admin) }
-    let(:topic) { create(:topic) }
+    let!(:topic) { create(:topic) }
+    let(:turbo_stream_headers) { { Accept: "text/vnd.turbo-stream.html" } }
 
     before { sign_in(user) }
 
-    it "deletes a Topic" do
-      delete topic_url(topic)
+    context "when first clickin on the Delete button" do
+      it "renders turbo stream to confirm deletion" do
+        expect { delete topic_url(topic), headers: turbo_stream_headers }
+        .not_to change(Topic, :count)
 
-      expect(response).to redirect_to(topics_url)
-      expect(Topic.count).to be_zero
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq "text/vnd.turbo-stream.html"
+      end
+    end
+
+    context "when deletion has been confirmed by the admin" do
+      it "deletes a Topic" do
+        delete topic_url(topic, confirmed: true)
+
+        expect(response).to redirect_to(topics_url)
+        expect(Topic.count).to be_zero
+      end
+
+      it "displays a success message" do
+        delete topic_url(topic, confirmed: true)
+
+        expect(flash[:notice]).to eq("Topic was successfully destroyed.")
+      end
+
+      context "when topic has documents" do
+        let(:topic) { create(:topic, :with_documents) }
+
+        before do
+          allow(DocumentsSyncJob).to receive(:perform_later)
+        end
+
+        it "runs sync job for documents" do
+          delete topic_url(topic, confirmed: true)
+
+          expect(response).to redirect_to(topics_url)
+          expect(DocumentsSyncJob).to have_received(:perform_later).with(hash_including(action: "delete"))
+        end
+      end
     end
 
     context "when user is not an admin" do
@@ -22,21 +56,6 @@ describe "Topics", type: :request do
 
         expect(response).to redirect_to(topics_url)
         expect(Topic.count).to eq(1)
-      end
-    end
-
-    context "when topic has documents" do
-      let(:topic) { create(:topic, :with_documents) }
-
-      before do
-        allow(DocumentsSyncJob).to receive(:perform_later)
-      end
-
-      it "runs sync job for documents" do
-        delete topic_url(topic)
-
-        expect(response).to redirect_to(topics_url)
-        expect(DocumentsSyncJob).to have_received(:perform_later).with(hash_including(action: "delete"))
       end
     end
   end

--- a/spec/requests/topics/unarchive_spec.rb
+++ b/spec/requests/topics/unarchive_spec.rb
@@ -14,6 +14,12 @@ describe "Topics", type: :request do
       expect(topic.reload.state).to eq("active")
     end
 
+    it "displays a success message" do
+      put unarchive_topic_url(topic)
+
+      expect(flash[:notice]).to eq("Topic was successfully reinstated.")
+    end
+
     context "when topic has documents" do
       let(:topic) { create(:topic, :with_documents, state: "archived") }
 

--- a/spec/requests/topics/update_spec.rb
+++ b/spec/requests/topics/update_spec.rb
@@ -11,15 +11,20 @@ RSpec.describe "Topics", type: :request do
   describe "PUT /topics/:id" do
     let(:user) { create(:user) }
     let(:topic) { create(:topic) }
+    let(:topic_params) { { title: "new topic", description: "updated" } }
 
     it "updates a Topic" do
-       topic_params = { title: "new topic", description: "updated" }
-
        put topic_url(topic), params: { topic: topic_params }
 
        topic.reload
        expect(topic.title).to eq("new topic")
        expect(topic.description).to eq("updated")
+    end
+
+    it "displays a success message" do
+      put topics_url, params: { topic: topic_params }
+
+      expect(flash[:notice]).to eq("Topic was successfully updated.")
     end
 
     context "when removing a tag" do


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #271 <!--fill issue number-->

### What Changed? And Why Did It Change?
It:

- adds a confirmation step before deleting a Topic, using the same pattern as what we have for Tags
- adds flash messages for successful operations on Topics and Languages (we already had those flash messages for Regions, Tags and Users)

### How Has This Been Tested?
With RSpec and by hand

### Please Provide Screenshots

https://github.com/user-attachments/assets/19fa4216-873f-4d75-8eba-06f9bbb22e4b


### Additional Comments
N/A
