### PR TITLE
Make edit buttons more prominent

### DIFF
--- a/app/views/providers/_provider.html.erb
+++ b/app/views/providers/_provider.html.erb
@@ -1,8 +1,5 @@
 <div id="<%= dom_id provider %>">
-  <p>
-    <strong>Name:</strong>
-    <%= provider.name %>
-  </p>
+  <h1><%= provider.name %></h1>
 
   <p>
     <strong>Provider type:</strong>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -2,9 +2,10 @@
 
 <%= render @provider %>
 
+<%= link_to "Back to providers", providers_path, class: "mt-4" %>
+
 <div>
-  <%= link_to "Edit this provider", edit_provider_path(@provider) %> |
-  <%= link_to "Back to providers", providers_path %>
+  <%= link_to "Edit this provider", edit_provider_path(@provider), class: "btn btn-primary mt-4" %>
 </div>
 
 <div>

--- a/app/views/regions/show.html.erb
+++ b/app/views/regions/show.html.erb
@@ -2,9 +2,10 @@
 
 <%= render @region %>
 
-<div class="mt-4">
-  <%= link_to "Edit this region", edit_region_path(@region) %> |
-  <%= link_to "Back to regions", regions_path %>
+<%= link_to "Back to regions", regions_path, class: "mt-4" %>
+
+<div>
+  <%= link_to "Edit this region", edit_region_path(@region), class: "btn btn-primary mt-4" %>
 </div>
 
 <div>

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,8 +1,5 @@
 <div id="<%= dom_id tag %>">
-  <p>
-    <strong>Name:</strong>
-    <%= tag.name %>
-  </p>
+  <h1><%= tag.name %></h1>
 
   <p>
     <strong>Cognates:</strong>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -3,10 +3,11 @@
 <%= render @tag %>
 
 <div id="<%= "delete_tag_#{@tag.id}" %>">
-  <div class="mt-4">
-    <%= link_to "Edit this tag", edit_tag_path(@tag) %> |
-    <%= link_to "Back to tags", tags_path %>
-  </div>
+  <%= link_to "Back to tags", tags_path, class: "mt-4" %>
+
+<div>
+  <%= link_to "Edit this tag", edit_tag_path(@tag), class: "btn btn-primary mt-4" %>
+</div>
 
   <% if Current.user.is_admin? %>
     <div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -2,9 +2,10 @@
 
 <%= render @topic %>
 
-<div class="mt-4">
-  <%= link_to "Edit this topic", edit_topic_path(@topic) %> |
-  <%= link_to "Back to topics", topics_path %>
+<%= link_to "Back to topics", topics_path, class: "mt-4" %>
+
+<div>
+  <%= link_to "Edit this topic", edit_topic_path(@topic), class: "btn btn-primary mt-4" %>
 </div>
 
 <% if @topic.archived? %>


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

@dcollie2 and I noted during the call on 19 July 2025 that the "Edit" buttons on "show" pages could be easy to miss, so this PR aims at addressing that by making those "Edit" buttons more prominent.

### What Changed? And Why Did It Change?
I changed the "Edit" links to buttons and also used a h1 headers for some page titles to make it easier to know at a glance what record we are looking at and to be more consistent with other views.

### How Has This Been Tested?
I clicked on the buttons to make sure they still work

### Please Provide Screenshots
#### Regions before/after
<img width="312" height="235" alt="Regions show before" src="https://github.com/user-attachments/assets/661402d2-f1ab-40da-a56d-31d76d730115" />         <img width="250" height="293" alt="Regions show after" src="https://github.com/user-attachments/assets/4f3a9bc1-15ca-44cb-99b5-30228ec9be51" />

#### Topics before/after
<img width="1610" height="836" alt="Topics show before" src="https://github.com/user-attachments/assets/7cf30e85-f2da-4ec4-817a-fea51c1d9c45" />
<img width="1611" height="903" alt="Topics show after" src="https://github.com/user-attachments/assets/3fa103a1-7cbc-4b18-99a9-24012e170bb4" />


#### Providers before/after
<img width="375" height="393" alt="Providers show before" src="https://github.com/user-attachments/assets/9e4de859-8296-4f40-9789-ac997ad309c6" />      <img width="384" height="539" alt="Providers show after" src="https://github.com/user-attachments/assets/c0674ac6-6bec-4b34-b014-3ca7d99a77c8" />

#### Tags before/after

<img width="399" height="378" alt="Tags show before" src="https://github.com/user-attachments/assets/966fd672-ee6e-46c4-8710-fb7cae2f1aff" />     <img width="419" height="445" alt="Tags show after" src="https://github.com/user-attachments/assets/6e628ff7-2516-43cc-9eb7-261910df5a15" />

### Additional Comments
