### PR TITLE
  Fix authentication redirect from mounted engines

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -35,7 +35,7 @@ module Authentication
 
     def request_authentication
       session[:return_to_after_authenticating] = request.url
-      redirect_to new_session_path
+      redirect_to main_app.new_session_path
     end
 
     def after_authentication_url

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe "Jobs", type: :request do
   let(:user) { create(:user, is_admin: false) }
 
-  before { sign_in(user) }
 
   context "contributor" do
+    before { sign_in(user) }
     it "cannot access the Jobs interface" do
       get "/jobs"
       expect(response).to have_http_status(:forbidden)
@@ -14,11 +14,22 @@ RSpec.describe "Jobs", type: :request do
   end
 
   context "administrator" do
-    before { user.update(is_admin: true) }
+    before do
+      sign_in(user)
+        user.update(is_admin: true)
+    end
 
     it "can access the Jobs interface" do
       get "/jobs"
       expect(response).to be_successful
+    end
+  end
+
+  context "not authenticated" do
+    it "redirects to the login page" do
+      get "/jobs"
+      expect(response).to redirect_to("/session/new")
+      expect(session[:return_to_after_authenticating]).to end_with("/jobs/")
     end
   end
 end


### PR DESCRIPTION
Use main_app.new_session_path to ensure redirects work correctly when unauthenticated requests come from mounted engines like Mission Control Jobs at `/jobs`
