### PR TITLE
Fix/limit concurrency file uploads

### DIFF
--- a/app/jobs/file_upload_job.rb
+++ b/app/jobs/file_upload_job.rb
@@ -1,7 +1,7 @@
 class FileUploadJob < ApplicationJob
   # Consider removing concurrency limits due to SolidQueue blocking issues
   # or use a more specific key to avoid blocking all jobs for a language
-  limits_concurrency key: ->(language_id, file_id, provider_id) { "#{language_id}-#{provider_id}" }
+  limits_concurrency key: ->(language_id, id, type) { "#{language_id}-#{id}" }
 
   retry_on AzureFileShares::Errors::ApiError, wait: :exponentially_longer, attempts: 3
   retry_on Timeout::Error, wait: :exponentially_longer, attempts: 2
@@ -12,17 +12,17 @@ class FileUploadJob < ApplicationJob
     Rails.logger.error "Suggestion: Check provider names for invalid characters if Azure API errors"
   end
 
-  def perform(language_id, file_id = nil, provider_id = nil, share = ENV["AZURE_STORAGE_SHARE_NAME"])
+  def perform(language_id, content_id, content_type, share = ENV["AZURE_STORAGE_SHARE_NAME"])
     @language = Language.find(language_id)
     @processor = LanguageContentProcessor.new(language)
     @share = share
 
-    if provider_id
-      send_provider_content(provider_id)
+    if content_type == :provider
+      send_provider_content(content_id)
       return
     end
 
-    send_language_content(file_id.to_sym)
+    send_language_content(content_id.to_sym)
   end
 
   private

--- a/app/services/language_content_processor.rb
+++ b/app/services/language_content_processor.rb
@@ -79,11 +79,11 @@ class LanguageContentProcessor
 
   def process_language_content!
     language_files.keys.each do |file_id|
-      FileUploadJob.perform_later(language.id, file_id.to_s, :file)
+      FileUploadJob.perform_later(language.id, file_id.to_s, "file")
     end
 
     language.providers.distinct.find_each do |provider|
-      FileUploadJob.perform_later(language.id, provider.id, :provider)
+      FileUploadJob.perform_later(language.id, provider.id, "provider")
     end
   end
 end

--- a/app/services/language_content_processor.rb
+++ b/app/services/language_content_processor.rb
@@ -79,11 +79,11 @@ class LanguageContentProcessor
 
   def process_language_content!
     language_files.keys.each do |file_id|
-      FileUploadJob.perform_later(language.id, file_id.to_s)
+      FileUploadJob.perform_later(language.id, file_id.to_s, :file)
     end
 
     language.providers.distinct.find_each do |provider|
-      FileUploadJob.perform_later(language.id, nil, provider.id)
+      FileUploadJob.perform_later(language.id, provider.id, :provider)
     end
   end
 end

--- a/spec/jobs/file_upload_job_spec.rb
+++ b/spec/jobs/file_upload_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe FileUploadJob, type: :job do
             file: file.content[language],
           )
 
-          described_class.perform_now(language.id, file_id.to_s)
+          described_class.perform_now(language.id, file_id.to_s, "file")
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe FileUploadJob, type: :job do
           )
         end
 
-        described_class.perform_now(language.id, nil, provider.id)
+        described_class.perform_now(language.id, provider.id, "provider")
       end
     end
   end

--- a/spec/services/language_content_processor_spec.rb
+++ b/spec/services/language_content_processor_spec.rb
@@ -20,15 +20,15 @@ RSpec.describe LanguageContentProcessor do
 
     expect(FileUploadJob).to have_received(:perform_later).exactly(files_number).times
 
-    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers")
-    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers_recent")
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tags")
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tags_and_title")
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "files")
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topics")
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tag_details")
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topic_tags")
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topic_authors")
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, nil, provider.id)
+    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers", :file)
+    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers_recent", :file)
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tags", :file)
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tags_and_title", :file)
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "files", :file)
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topics", :file)
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tag_details", :file)
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topic_tags", :file)
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topic_authors", :file)
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, provider.id, :provider)
   end
 end

--- a/spec/services/language_content_processor_spec.rb
+++ b/spec/services/language_content_processor_spec.rb
@@ -20,15 +20,15 @@ RSpec.describe LanguageContentProcessor do
 
     expect(FileUploadJob).to have_received(:perform_later).exactly(files_number).times
 
-    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers", :file)
-    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers_recent", :file)
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tags", :file)
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tags_and_title", :file)
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "files", :file)
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topics", :file)
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tag_details", :file)
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topic_tags", :file)
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topic_authors", :file)
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, provider.id, :provider)
+    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers", "file")
+    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers_recent", "file")
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tags", "file")
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tags_and_title", "file")
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "files", "file")
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topics", "file")
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tag_details", "file")
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topic_tags", "file")
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topic_authors", "file")
+    expect(FileUploadJob).to have_received(:perform_later).with(language.id, provider.id, "provider")
   end
 end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

`FileUploadJob` now has concurrency limit. This setting expect fixed number of arguments, exactly 3.
This is why job fails when we pass 2 arguments in case of language file upload.
https://staging.skillrx.org/jobs/applications/skillrx/jobs/762a0182-1689-41ba-ae5e-537c9ce59755?server_id=solid_queue#error

### What Changed? And Why Did It Change?

Always using 3 arguments for `FileUploadJob`

### How Has This Been Tested?

Tests were updated

### Please Provide Screenshots

### Additional Comments
