### PR TITLE
Feat/try ox for xml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "faker"
-  gem "memory_profiler"
   gem "rspec-rails"
   gem "rubocop-rails-omakase", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "importmap-rails"
 gem "jbuilder"
 gem "kamal", require: false
 gem "mission_control-jobs"
+gem "ox"
 gem "pagy"
 gem "pg", "~> 1.6"
 gem "propshaft"

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "faker"
+  gem "memory_profiler"
   gem "rspec-rails"
   gem "rubocop-rails-omakase", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.3)
+    memory_profiler (1.1.0)
     mini_magick (5.3.0)
       logger
     mini_mime (1.1.5)
@@ -544,6 +545,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
+  memory_profiler
   mission_control-jobs
   ox
   pagy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,6 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.3)
-    memory_profiler (1.1.0)
     mini_magick (5.3.0)
       logger
     mini_mime (1.1.5)
@@ -545,7 +544,6 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
-  memory_profiler
   mission_control-jobs
   ox
   pagy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,8 @@ GEM
     nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.3)
+    ox (2.14.23)
+      bigdecimal (>= 3.0)
     pagy (9.3.5)
     parallel (1.27.0)
     parser (3.3.9.0)
@@ -543,6 +545,7 @@ DEPENDENCIES
   kamal
   letter_opener
   mission_control-jobs
+  ox
   pagy
   pg (~> 1.6)
   propshaft

--- a/app/services/xml_generator/all_providers.rb
+++ b/app/services/xml_generator/all_providers.rb
@@ -8,8 +8,6 @@ class XmlGenerator::AllProviders < XmlGenerator::SingleProvider
 
   def xml_content(xml)
     language.providers.includes(:topics)
-      .map do |provider|
-        provider_xml(xml, provider)
-      end
+      .map { |provider| provider_xml(xml, provider) }
   end
 end

--- a/app/services/xml_generator/all_providers.rb
+++ b/app/services/xml_generator/all_providers.rb
@@ -8,6 +8,8 @@ class XmlGenerator::AllProviders < XmlGenerator::SingleProvider
 
   def xml_content(xml)
     language.providers.includes(:topics)
-      .map { |provider| provider_xml(xml, provider) }
+      .each do |provider|
+        xml << provider_xml(provider)
+      end
   end
 end

--- a/app/services/xml_generator/base.rb
+++ b/app/services/xml_generator/base.rb
@@ -9,8 +9,6 @@ class XmlGenerator::Base
     Ox::Document.new.tap do |doc|
       instruct = Ox::Instruct.new(:xml)
       instruct[:version] = "1.0"
-      instruct[:encoding] = "UTF-8"
-      instruct[:standalone] = "yes"
       doc << instruct
 
       xml = Ox::Element.new("cmes")

--- a/app/services/xml_generator/base.rb
+++ b/app/services/xml_generator/base.rb
@@ -1,13 +1,21 @@
 class XmlGenerator::Base
   def perform
-    builder.to_xml
+    Ox.dump(builder)
   end
 
   private
 
   def builder
-    Nokogiri::XML::Builder.new do |xml|
-      xml.cmes { xml_content(xml) }
+    Ox::Document.new.tap do |doc|
+      instruct = Ox::Instruct.new(:xml)
+      instruct[:version] = "1.0"
+      instruct[:encoding] = "UTF-8"
+      instruct[:standalone] = "yes"
+      doc << instruct
+
+      xml = Ox::Element.new("cmes")
+      xml_content(xml)
+      doc << xml
     end
   end
 end

--- a/app/services/xml_generator/single_provider.rb
+++ b/app/services/xml_generator/single_provider.rb
@@ -16,21 +16,21 @@ class XmlGenerator::SingleProvider < XmlGenerator::Base
     Ox::Element.new("content_provider").tap do |xml|
       xml[:name] = provider.name
 
-      xml << grouped_topics(provider).each do |(year, month), topics|
-        Ox::Element.new("topic_year").tap do |year_element|
+      grouped_topics(provider).each do |(year, month), topics|
+        xml << Ox::Element.new("topic_year").tap do |year_element|
           year_element[:year] = year.to_s
           year_element << Ox::Element.new("topic_month").tap do |month_element|
             month_element[:month] = month
-            month_element << topics.each do |topic|
+            topics.each do |topic|
               month_element << Ox::Element.new("title").tap do |title_element|
                 title_element[:name] = topic.title
-                title_element << Ox::Element.new("topic_id").tap { |id| id << topic.id }
+                title_element << Ox::Element.new("topic_id").tap { |id| id << topic.id.to_s }
                 title_element << Ox::Element.new("topic_files").tap do |files|
                   files[:files] = "Files"
                   topic.documents.each_with_index do |document, index|
                     next if document.content_type == "video/mp4"
                     files << Ox::Element.new("file_name_#{index + 1}").tap do |file_name|
-                      file_name << document.filename
+                      file_name << document.filename.to_s
                       file_name[:file_size] = document.byte_size
                     end
                   end

--- a/app/services/xml_generator/single_provider.rb
+++ b/app/services/xml_generator/single_provider.rb
@@ -9,30 +9,59 @@ class XmlGenerator::SingleProvider < XmlGenerator::Base
   attr_reader :provider, :args
 
   def xml_content(xml)
-    provider_xml(xml, provider)
+    xml << provider_xml(provider)
   end
 
-  def provider_xml(xml, provider)
-    xml.content_provider(name: provider.name) {
-      grouped_topics(provider).each do |(year, month), topics|
-        xml.topic_year(year: year) {
-          xml.topic_month(month: month) {
-            topics.each do |topic|
-              xml.title(name: topic.title) {
-                xml.topic_id topic.id
-                xml.topic_files(files: "Files") {
+  def provider_xml(provider)
+    Ox::Element.new("content_provider").tap do |xml|
+      xml[:name] = provider.name
+
+      xml << grouped_topics(provider).each do |(year, month), topics|
+        Ox::Element.new("topic_year").tap do |year_element|
+          year_element[:year] = year.to_s
+          year_element << Ox::Element.new("topic_month").tap do |month_element|
+            month_element[:month] = month
+            month_element << topics.each do |topic|
+              month_element << Ox::Element.new("title").tap do |title_element|
+                title_element[:name] = topic.title
+                title_element << Ox::Element.new("topic_id").tap { |id| id << topic.id }
+                title_element << Ox::Element.new("topic_files").tap do |files|
+                  files[:files] = "Files"
                   topic.documents.each_with_index do |document, index|
                     next if document.content_type == "video/mp4"
-                    xml.send("file_name_#{index + 1}", document.filename, file_size: document.byte_size)
+                    files << Ox::Element.new("file_name_#{index + 1}").tap do |file_name|
+                      file_name << document.filename
+                      file_name[:file_size] = document.byte_size
+                    end
                   end
-                }
-                xml.topic_tags topic.current_tags_list.join(", ")
-              }
+                end
+                title_element << Ox::Element.new("topic_tags").tap { |tags| tags << topic.current_tags_list.join(", ") }
+              end
             end
-          }
-        }
+          end
+        end
       end
-    }
+    end
+    # xml.content_provider(name: provider.name) {
+    #   grouped_topics(provider).each do |(year, month), topics|
+    #     xml.topic_year(year: year) {
+    #       xml.topic_month(month: month) {
+    #         topics.each do |topic|
+    #           xml.title(name: topic.title) {
+    #             xml.topic_id topic.id
+    #             xml.topic_files(files: "Files") {
+    #               topic.documents.each_with_index do |document, index|
+    #                 next if document.content_type == "video/mp4"
+    #                 xml.send("file_name_#{index + 1}", document.filename, file_size: document.byte_size)
+    #               end
+    #             }
+    #             xml.topic_tags topic.current_tags_list.join(", ")
+    #           }
+    #         end
+    #       }
+    #     }
+    #   end
+    # }
   end
 
   def grouped_topics(prov)

--- a/app/services/xml_generator/single_provider.rb
+++ b/app/services/xml_generator/single_provider.rb
@@ -42,26 +42,6 @@ class XmlGenerator::SingleProvider < XmlGenerator::Base
         end
       end
     end
-    # xml.content_provider(name: provider.name) {
-    #   grouped_topics(provider).each do |(year, month), topics|
-    #     xml.topic_year(year: year) {
-    #       xml.topic_month(month: month) {
-    #         topics.each do |topic|
-    #           xml.title(name: topic.title) {
-    #             xml.topic_id topic.id
-    #             xml.topic_files(files: "Files") {
-    #               topic.documents.each_with_index do |document, index|
-    #                 next if document.content_type == "video/mp4"
-    #                 xml.send("file_name_#{index + 1}", document.filename, file_size: document.byte_size)
-    #               end
-    #             }
-    #             xml.topic_tags topic.current_tags_list.join(", ")
-    #           }
-    #         end
-    #       }
-    #     }
-    #   end
-    # }
   end
 
   def grouped_topics(prov)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -107,3 +107,21 @@ end
 end
 
 puts "Users created!"
+
+if ENV["SEED_MODE_HEAVY_LOAD"]
+  times = ENV["SEED_MODE_HEAVY_LOAD"].to_i
+  times.times do
+    provider = Provider.find_or_create_by!(name: Faker::Company.name, provider_type: "government")
+    times.times do
+      Topic.find_or_create_by!(
+        title: Faker::Book.title,
+        description: Faker::Lorem.paragraph,
+        language_id: Language.first.id,
+        provider_id: provider.id,
+        uid: SecureRandom.uuid,
+        published_at: Time.now - rand(1..365).days,
+        state: [ :active, :archived ].sample,
+      )
+    end
+  end
+end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Memory consumption by XML generating code is too high. Mostly because of Nokogiri gem.

### What Changed? And Why Did It Change?

* rewrite code to using [ox gem](https://github.com/ohler55/ox)
* added "tons of records" mode to DB seeds, this setup is hidden with env var
* tried to check consumption with memory profiler, below is what I get

Before:
```
allocated memory by gem
-----------------------------------
 461205067  nokogiri-1.18.9-arm64-darwin
 215906294  scout_apm-5.6.5
```

After:
```
allocated memory by gem
-----------------------------------
 215849416  scout_apm-5.6.5
 177965770  activerecord-8.0.2
 118765512  skillrx/app
 112950000  ox-2.14.23
```

We can see that Ox itself eats like 3x less memory than Nokogiri

### How Has This Been Tested?

Existing tests for XML generation should pass

### Please Provide Screenshots

### Additional Comments

With this changes we can try to enable XML files again