### PR TITLE
Small UX improvements on topic pages

### DIFF
--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -24,18 +24,18 @@
                                     Language.all,
                                     :id,
                                     :name,
-                                    { prompt: "Select Language" },
+                                    { prompt: "Select language", selected: topic.language&.id || Language.first.id },
                                     class: "form-select",
                                     data: { "resource-type": "topics", "resource-id": f.object.id, "select-tags-target": "language", "action": "change->select-tags#changeLanguage" }
             %>
           </div>
           <div class="form-group">
             <%= f.label :publishing_year %>
-            <%= f.select :published_at_year, options_for_select((2016..Date.today.year).to_a, topic.published_at_year), { prompt: "Select year of publishing" }, class: "form-select" %>
+            <%= f.select :published_at_year, options_for_select((2016..Date.today.year).to_a, topic.published_at_year || Date.today.year), { prompt: "Select year of publishing" }, class: "form-select" %>
           </div>
           <div class="form-group">
             <%= f.label :publishing_month %>
-            <%= f.select :published_at_month, options_for_select((1..12).to_a, topic.published_at_month), { prompt: "Select month of publishing" }, class: "form-select" %>
+            <%= f.select :published_at_month, options_for_select((1..12).to_a, topic.published_at_month || Date.today.month), { prompt: "Select month of publishing" }, class: "form-select" %>
           </div>
           <div class="form-group">
             <div class="d-flex">

--- a/app/views/topics/_list.html.erb
+++ b/app/views/topics/_list.html.erb
@@ -9,7 +9,7 @@
       <td class="text-bold-500"><%= topic.documents.size %></td>
       <td class="text-bold-500"><span class="badge <%= topic.state == "active" ? "bg-success" : "bg-light-danger" %>"><%= topic.state %></span></td>
       <td class="text-end">
-        <%= link_to topic, class: "btn btn-primary btn-sm", data: { turbo: false } do %>
+        <%= link_to topic_path(topic, search: search_params), class: "btn btn-primary btn-sm", data: { turbo: false } do %>
           <i class="bi bi-search"></i> View
         <% end %>
         <%= link_to edit_topic_path(topic), class: "btn btn-secondary btn-sm", data: { turbo: false } do %>

--- a/app/views/topics/_search.html.erb
+++ b/app/views/topics/_search.html.erb
@@ -37,7 +37,7 @@
             <div class="col-md-6 col-12">
               <div class="form-group">
                 <%= f.label :language %>
-                <%= f.select :language_id, options_from_collection_for_select(languages, :id, :name, params[:provider_id]),  { prompt: "Select language" }, class: "form-select", data: { action: "change->topics#searchTopics" } %>
+                <%= f.select :language_id, options_from_collection_for_select(languages, :id, :name, params[:language_id]),  { prompt: "Select language" }, class: "form-select", data: { action: "change->topics#searchTopics" } %>
               </div>
             </div>
             <div class="col-md-3 col-12">

--- a/app/views/topics/_search.html.erb
+++ b/app/views/topics/_search.html.erb
@@ -22,7 +22,7 @@
                 </div>
                 <%= f.select :tag_list,
                              options_from_collection_for_select(
-                               Tag.all,
+                               Tag.order(:name),
                                :name,
                                :name,
                                []

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -32,7 +32,7 @@
                         <th class="text-end">Actions</th>
                       </tr>
                     </thead>
-                    <%= render "list", topics: @topics %>
+                    <%= render "list", topics: @topics, params: search_params %>
                   </table>
                 </div>
                 <div class="card-footer d-flex justify-content-end">

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render @topic %>
 
-<%= link_to "Back to topics", topics_path, class: "mt-4" %>
+<%= link_to "Back to topics", topics_path(search: search_params), class: "mt-4" %>
 
 <div>
   <%= link_to "Edit this topic", edit_topic_path(@topic), class: "btn btn-primary mt-4" %>

--- a/spec/system/upload_management_spec.rb
+++ b/spec/system/upload_management_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Upload Management", type: :system do
 
   before do
     login_as(admin)
+    create(:language)
   end
 
   context "when creating a new topic" do


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

This is something we discussed on the call on 2 August, 2025.

### What Changed? And Why Did It Change?
This makes a few UX improvements on Topic-related pages:

- sort the Tag list alphabetically
- pre-select the language, year and month fields when creating a Topic
- maintain search params when clicking on "Back to topics"

### How Has This Been Tested?
By hand

### Please Provide Screenshots
<img width="777" height="806" alt="Topic form with preselected fields" src="https://github.com/user-attachments/assets/9895f970-f4d4-43e8-b4ac-35ad3c210357" />

<img width="781" height="392" alt="Tag search with sorted tags" src="https://github.com/user-attachments/assets/7c5f58b9-e1de-4478-9ee4-071c71ccf5c5" />

https://github.com/user-attachments/assets/a6c92a10-083a-4900-ae26-21a0b591c459


### Additional Comments
N/A
