### PR TITLE
Rename files on upload

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -31,17 +31,9 @@ class UploadsController < ApplicationController
     params.require(:documents).map do |document|
       {
         io: document,
-        filename: derived_filename(document), # You can customize this as needed
+        filename: document.original_filename,
         content_type: document.content_type,
       }
     end
-  end
-
-
-  def derived_filename(document)
-    [
-      "rename",
-      document.original_filename,
-    ].join("_")
   end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -31,9 +31,17 @@ class UploadsController < ApplicationController
     params.require(:documents).map do |document|
       {
         io: document,
-        filename: document.original_filename,
+        filename: derived_filename(document), # You can customize this as needed
         content_type: document.content_type,
       }
     end
+  end
+
+
+  def derived_filename(document)
+    [
+      "rename",
+      document.original_filename,
+    ].join("_")
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -57,6 +57,16 @@ class Topic < ApplicationRecord
     id
   end
 
+  def custom_file_name(document)
+    [
+      id,
+      provider.file_name_prefix.present? ? provider.file_name_prefix.parameterize : provider.name.parameterize(separator: "_"),
+      published_at_year,
+      published_at_month,
+      document.filename.base.sub("rename_", "").parameterize(separator: "_"),
+    ].compact.join("_") + "." + document.filename.extension
+  end
+
   class << self
     def by_year(year)
       where("extract(year from published_at) = ?", year)

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -63,7 +63,7 @@ class Topic < ApplicationRecord
       provider.file_name_prefix.present? ? provider.file_name_prefix.parameterize : provider.name.parameterize(separator: "_"),
       published_at_year,
       published_at_month,
-      document.filename.base.sub("rename_", "").parameterize(separator: "_"),
+      document.filename.base.parameterize(separator: "_"),
     ].compact.join("_") + "." + document.filename.extension
   end
 

--- a/app/services/file_manager.rb
+++ b/app/services/file_manager.rb
@@ -77,21 +77,9 @@ class FileManager
     @file_content ||= document.download
   end
 
-  # naming convention described here: https://github.com/rubyforgood/skillrx/issues/305
-  # [topic.id]_[provider.provider_name_for_file]_[topic.published_at_year]_[topic.published_at_month][document.filename.parameterize].[extension]
+  # naming convention now enforced on upload
   def file_name
-    provider = topic.provider
-    @file_name ||= [].tap do |parts|
-      parts << topic.id
-      if provider.file_name_prefix.present?
-        parts << provider.file_name_prefix
-      else
-        parts << provider.name
-      end
-      parts << topic.published_at_year
-      parts << format("%02d", topic.published_at_month)
-      parts << document.filename
-    end.join("_")
+    document.filename.to_s
   end
 
   def language

--- a/app/services/topics/mutator.rb
+++ b/app/services/topics/mutator.rb
@@ -78,7 +78,7 @@ class Topics::Mutator
     document = topic.documents.find { |doc| doc.blob.signed_id == signed_id }
       next unless document
 
-      new_filename = custom_file_name(document)
+      new_filename = topic.custom_file_name(document)
       rename_document(document, new_filename)
     end
   end
@@ -94,16 +94,6 @@ class Topics::Mutator
         content_type: document.content_type
       )
       document.purge
-  end
-
-  def custom_file_name(document)
-    [
-      topic.id,
-      topic.provider.file_name_prefix.present? ? topic.provider.file_name_prefix.parameterize : topic.provider.name.parameterize,
-      topic.published_at_year,
-      topic.published_at_month,
-      document.filename.base.sub("rename_", "").parameterize,
-    ].compact.join("_") + "." + document.filename.extension
   end
 
   def sync_docs_for_topic_updates

--- a/spec/jobs/documents_sync_job_spec.rb
+++ b/spec/jobs/documents_sync_job_spec.rb
@@ -4,15 +4,7 @@ RSpec.describe DocumentsSyncJob, type: :job do
   let(:topic) { create(:topic, :with_documents) }
   let(:provider) { topic.provider }
   let(:document) { topic.documents.first }
-  let(:file_name) do
-    [
-      topic.id,
-      provider.file_name_prefix,
-      topic.published_at_year,
-      format("%02d", topic.published_at_month),
-      document.filename,
-    ].join("_")
-  end
+  let(:file_name) { document.filename }
 
   before { provider.update(file_name_prefix: "MyPrefix") }
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -43,4 +43,29 @@ RSpec.describe Topic, type: :model do
   context "tagging" do
     it_behaves_like "taggable"
   end
+
+  describe "#custom_file_name" do
+    let(:document) { double("Document", filename: ActiveStorage::Filename.new("Document name.pdf")) }
+    let(:topic) { create(:topic, provider: provider, published_at: Time.new(2023, 12, 22)) }
+
+    context "when provider has a file name prefix" do
+      let(:provider) { create(:provider, file_name_prefix: "prefix") }
+
+      it "returns a custom file name based on topic attributes" do
+        expect(topic.custom_file_name(document)).to eq(
+          "#{topic.id}_prefix_2023_12_document_name.pdf"
+        )
+      end
+    end
+
+    context "when provider does not have a file name prefix" do
+      let(:provider) { create(:provider, file_name_prefix: nil, name: "Provider Name") }
+
+      it "returns a custom file name based on topic attributes" do
+        expect(topic.custom_file_name(document)).to eq(
+          "#{topic.id}_provider_name_2023_12_document_name.pdf"
+        )
+      end
+    end
+  end
 end

--- a/spec/services/file_manager_spec.rb
+++ b/spec/services/file_manager_spec.rb
@@ -29,14 +29,14 @@ RSpec.describe FileManager do
     it "initializes file workers with correct parameters" do
       expect(FileWorker).to receive(:new).with(
         share:,
-        name: "#{topic.id}_MyPrefix_#{topic.published_at_year}_#{format('%02d', topic.published_at_month)}_dummy.pdf",
+        name: "dummy.pdf",
         path: "#{topic.language.file_storage_prefix}CMES-Pi/assets/Content",
         file: document.download,
         new_path: nil,
       ).and_call_original
       expect(FileWorker).to receive(:new).with(
         share:,
-        name: "#{topic.id}_MyPrefix_#{topic.published_at_year}_#{format('%02d', topic.published_at_month)}_dummy.pdf",
+        name: "dummy.pdf",
         path: "#{topic.language.file_storage_prefix}CMES-v2/assets/Content",
         file: document.download,
         new_path: nil,
@@ -64,7 +64,7 @@ RSpec.describe FileManager do
       it "initializes file worker with parameters for video" do
         expect(FileWorker).to receive(:new).with(
           share:,
-          name: "#{topic.id}_MyPrefix_#{topic.published_at_year}_#{format('%02d', topic.published_at_month)}_video_file.mp4",
+          name: "video_file.mp4",
           path: "#{topic.language.file_storage_prefix}CMES-v2/assets/VideoContent",
           file: document.download,
           new_path: nil,


### PR DESCRIPTION
This moves our document filename enforcement into SkillRX instead of handling it when syncing documents to Azure. It does this by prefixing new documents with "rename" then, in the mutator, finding the attachments with that prefix, reattaching them with their new name, and removing their prior version.
