### PR TITLE
Small changes in TopicsMutator

### DIFF
--- a/app/services/topics/mutator.rb
+++ b/app/services/topics/mutator.rb
@@ -53,8 +53,7 @@ class Topics::Mutator
     ActiveRecord::Base.transaction do
       topic.save_with_tags(params)
       attach_files(document_signed_ids)
-      # topic.persisted? means that we are updating existing topic and documents can be removed
-      shadow_delete_documents(docs_to_delete) if topic.persisted?
+      shadow_delete_documents(docs_to_delete)
       rename_files(document_signed_ids)
       # document_signed_ids.any? means that some new documents were attached and we need to sync them
       sync_docs_for_topic_updates if document_signed_ids.any?
@@ -75,7 +74,7 @@ class Topics::Mutator
   def rename_files(signed_ids)
     return if signed_ids.blank?
     signed_ids.each do |signed_id|
-    document = topic.documents.find { |doc| doc.blob.signed_id == signed_id }
+      document = topic.documents.find { |doc| doc.blob.signed_id == signed_id }
       next unless document
 
       new_filename = topic.custom_file_name(document)

--- a/spec/services/topics/mutator_spec.rb
+++ b/spec/services/topics/mutator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Topics::Mutator do
       [
         ActiveStorage::Blob.create_and_upload!(
           io: StringIO.new("dummy content"),
-          filename: "dummy.pdf",
+          filename: "rename_dummy.pdf",
           content_type: "application/pdf",
         ).signed_id,
       ]
@@ -41,6 +41,7 @@ RSpec.describe Topics::Mutator do
         document_id: created_topic.documents.first.id,
         action: "update",
       )
+      expect(created_topic.reload.documents.first.blob.filename.to_s).to eq("#{created_topic.id}_prefix_2023_1_dummy.pdf")
     end
   end
 
@@ -86,6 +87,10 @@ RSpec.describe Topics::Mutator do
         expect(status).to eq(:ok)
         expect(updated_topic).to be_persisted
         expect(updated_topic.description).to eq("many topic details")
+      end
+
+      it "does not rename existing documents" do
+        expect { subject.update }.not_to change { topic.reload.documents.first.blob.filename.to_s }.from("test_image.png")
       end
     end
   end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

N/A

### What Changed? And Why Did It Change?
It makes some minor changes in TopicsMutator:

- removes a redundant condition that currently always returns true (see 1st commit message for more details)
- fixes the indentation
- add some tests for the file renaming behaviour

### How Has This Been Tested?
RSpec

### Please Provide Screenshots
N/A

### Additional Comments
N/A