### PR TITLE
chore: add concurrency option for staging deploys from CI

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest
+
+    concurrency:
+      group: deploy-staging
+      cancel-in-progress: false
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

When two CI deploy actions run one-by-one, second one will fail because of deploy lock from Kamal

### What Changed? And Why Did It Change?

Concurrency option should prevent two deploys running in parallel:
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency

### How Has This Been Tested?

### Please Provide Screenshots

### Additional Comments
