### PR TITLE
Disable Topic form button until upload completes

### DIFF
--- a/app/javascript/controllers/upload_controller.js
+++ b/app/javascript/controllers/upload_controller.js
@@ -1,10 +1,18 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["filesInput", "fileItem", "filesContainer", "hiddenField"];
+  static targets = [
+    "filesInput",
+    "fileItem",
+    "filesContainer",
+    "hiddenField",
+    "submitButton",
+  ];
 
   uploadFile(event) {
     event.preventDefault();
+
+    this.submitButtonTarget.classList.add("disabled");
 
     const filesInput = this.filesInputTarget;
     let files = Array.from(filesInput.files);
@@ -33,6 +41,8 @@ export default class extends Controller {
           filesInput.value = "";
         }
       });
+
+    this.submitButtonTarget.classList.remove("disabled");
   }
 
   removeFile(event) {

--- a/app/javascript/controllers/upload_controller.js
+++ b/app/javascript/controllers/upload_controller.js
@@ -7,12 +7,14 @@ export default class extends Controller {
     "filesContainer",
     "hiddenField",
     "submitButton",
+    "spinner",
   ];
 
   uploadFile(event) {
     event.preventDefault();
 
     this.submitButtonTarget.classList.add("disabled");
+    this.spinnerTarget.classList.remove("d-none");
 
     const filesInput = this.filesInputTarget;
     let files = Array.from(filesInput.files);
@@ -43,6 +45,7 @@ export default class extends Controller {
       });
 
     this.submitButtonTarget.classList.remove("disabled");
+    this.spinnerTarget.classList.add("d-none");
   }
 
   removeFile(event) {

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -71,10 +71,10 @@
           <% end %>
 
           <%= f.file_field :documents, multiple: true, class: "form-control mt-4", id: "documents", data: { upload_target: "filesInput", action: "change->upload#uploadFile" } %>
-        </div>
-        <div class="col-12 d-flex justify-content-end">
-          <%= f.submit class: "btn btn-primary me-1 mb-1" %>
-          <%= link_to "Cancel", topics_path, class: "btn btn-light-secondary me-1 mb-1" %>
+          <div class="col-12 d-flex justify-content-end mt-4">
+            <%= f.submit class: "btn btn-primary me-1 mb-1", data: { upload_target: "submitButton" } %>
+            <%= link_to "Cancel", topics_path, class: "btn btn-light-secondary me-1 mb-1" %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -71,6 +71,14 @@
           <% end %>
 
           <%= f.file_field :documents, multiple: true, class: "form-control mt-4", id: "documents", data: { upload_target: "filesInput", action: "change->upload#uploadFile" } %>
+
+          <div class="d-none" data-upload-target="spinner">
+            <div class="spinner-border spinner-border-sm mt-4" role="status">
+              <span class="visually-hidden">Uploading in progress...</span>
+            </div>
+            <span>Uploading in progress...</span>
+          </div>
+
           <div class="col-12 d-flex justify-content-end mt-4">
             <%= f.submit class: "btn btn-primary me-1 mb-1", data: { upload_target: "submitButton" } %>
             <%= link_to "Cancel", topics_path, class: "btn btn-light-secondary me-1 mb-1" %>


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

This is an attempt at fixing the 500 error that Manoj has been encountering when uploading documents in the Topic form.
@amuta saw this error in the logs:

```
NoMethodError (undefined method 'signed_id' for an instance of ActionDispatch::Http::UploadedFile)

app/services/topics/mutator.rb:150
def extract_document_ids
  documents = params && params[:documents] || []
  documents.map { |doc| doc.is_a?(String) ? doc : doc.signed_id }
end
```

So I think the form may have been submitted before the upload was completed.

### What Changed? And Why Did It Change?
I added 2 lines to disable the submit button until the documents have fully uploaded.

### How Has This Been Tested?
I couldn't replicate the bug, but I checked by hand that the button could be disabled/re-enabled.

### Please Provide Screenshots

<img width="857" height="261" alt="Disabled button + spinner" src="https://github.com/user-attachments/assets/8af20ca8-68a1-47e7-a814-b1e941f0a8b3" />

### Additional Comments
N/A
