### PR TITLE
Fix disabling button during file upload

### DIFF
--- a/app/javascript/controllers/upload_controller.js
+++ b/app/javascript/controllers/upload_controller.js
@@ -42,10 +42,10 @@ export default class extends Controller {
           this.filesContainerTarget.innerHTML += data.html;
           filesInput.value = "";
         }
-      });
 
-    this.submitButtonTarget.classList.remove("disabled");
-    this.spinnerTarget.classList.add("d-none");
+        this.submitButtonTarget.classList.remove("disabled");
+        this.spinnerTarget.classList.add("d-none");
+      });
   }
 
   removeFile(event) {


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

This is a follow-up to https://github.com/rubyforgood/skillrx/pull/369 that meant to fix an issue that is causing a 500 error when submitting the Topic form before a file upload has fully completed.

### What Changed? And Why Did It Change?

The lines that were restoring the button state were outside of the promise, so they re-activated the button too early.

### How Has This Been Tested?
By hand

### Please Provide Screenshots

https://github.com/user-attachments/assets/f91704ea-dab1-4be6-9771-71496accd3b9



### Additional Comments
N/A
