### PR TITLE
Reload topic documents before syncing

### DIFF
--- a/app/services/topics/mutator.rb
+++ b/app/services/topics/mutator.rb
@@ -96,6 +96,7 @@ class Topics::Mutator
   end
 
   def sync_docs_for_topic_updates
+    topic.documents_attachments.reload
     topic.documents_attachments.each do |doc|
       DocumentsSyncJob.perform_later(
         topic_id: topic.id,


### PR DESCRIPTION
Document sync was running against a stale set of attachments.