### PR TITLE
fix: fetch tags when init tags controller

### DIFF
--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/select_tags_controller.js
+++ b/app/javascript/controllers/select_tags_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
 
   connect() {
     this.initializeTags()
+    this.changeLanguage();
   }
 
   notify() {
@@ -17,7 +18,7 @@ export default class extends Controller {
    * Handle language change event and update tags accordingly
    * @param {Event} event - Change event
    */
-  async changeLanguage(event) {
+  async changeLanguage(_event) {
     try {
       const { resourceId, languageId } = this.getIds()
 


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #387

### What Changed? And Why Did It Change?

The problem is that for new topic tag select field is not initialised fully: `Tags.init` is called, but we do not receive tags from internal API.
Tags received only when language change event happens
This PR adds code to force language change event, specifically for new topic.

### How Has This Been Tested?

### Please Provide Screenshots
For existing topic:
<img width="534" height="173" alt="Screenshot 2025-08-25 at 23 30 34" src="https://github.com/user-attachments/assets/54b3f522-138b-42df-8d5d-a4dcbf6a1361" />

For new topic:
<img width="526" height="237" alt="Screenshot 2025-08-25 at 23 30 49" src="https://github.com/user-attachments/assets/586fa985-996e-4397-bf75-4ba4ad8b7d55" />

### Additional Comments
