### PR TITLE
Revert large xml file generation

### DIFF
--- a/app/services/language_content_processor.rb
+++ b/app/services/language_content_processor.rb
@@ -25,16 +25,16 @@ class LanguageContentProcessor
   # this is needed to avoid loading all files into memory at once
   def language_files
     {
-      all_providers: FileToUpload.new(
-        content: ->(language) { XmlGenerator::AllProviders.new(language).perform },
-        name: "#{language.file_storage_prefix}Server_XML.xml",
-        path: "#{language.file_storage_prefix}CMES-Pi/assets/XML",
-      ),
-      all_providers_recent: FileToUpload.new(
-        content: ->(language) { XmlGenerator::AllProviders.new(language, recent: true).perform },
-        name: "#{language.file_storage_prefix}New_Uploads_Server_XML.xml",
-        path: "#{language.file_storage_prefix}CMES-Pi/assets/XML",
-      ),
+      # all_providers: FileToUpload.new(
+      #   content: ->(language) { XmlGenerator::AllProviders.new(language).perform },
+      #   name: "#{language.file_storage_prefix}Server_XML.xml",
+      #   path: "#{language.file_storage_prefix}CMES-Pi/assets/XML",
+      # ),
+      # all_providers_recent: FileToUpload.new(
+      #   content: ->(language) { XmlGenerator::AllProviders.new(language, recent: true).perform },
+      #   name: "#{language.file_storage_prefix}New_Uploads_Server_XML.xml",
+      #   path: "#{language.file_storage_prefix}CMES-Pi/assets/XML",
+      # ),
       tags: FileToUpload.new(
         content: ->(language) { TextGenerator::Tags.new(language).perform },
         name: "#{language.file_storage_prefix}tags.txt",

--- a/spec/services/language_content_processor_spec.rb
+++ b/spec/services/language_content_processor_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe LanguageContentProcessor do
   end
 
   it "processes content for every language" do
-    files_number = language.providers.size + 9 # 2 xml files for all provides, 2 text files for tags, 5 csv files
+    files_number = language.providers.size + 7 # 2 xml files for all provides, 2 text files for tags, 5 csv files
     subject.perform
 
     expect(FileUploadJob).to have_received(:perform_later).exactly(files_number).times
 
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers", "file")
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers_recent", "file")
+    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers", "file")
+    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, "all_providers_recent", "file")
     expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tags", "file")
     expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tags_and_title", "file")
     expect(FileUploadJob).to have_received(:perform_later).with(language.id, "files", "file")


### PR DESCRIPTION
We are still having performance issues with the large XML files. This pulls them back out of the process so we can clear the pipeline to deploy recent work.