### PR TITLE
fix: prevent FileUploadJob overload by limiting concurrency per language

### DIFF
--- a/app/jobs/file_upload_job.rb
+++ b/app/jobs/file_upload_job.rb
@@ -1,7 +1,7 @@
 class FileUploadJob < ApplicationJob
   # Consider removing concurrency limits due to SolidQueue blocking issues
   # or use a more specific key to avoid blocking all jobs for a language
-  limits_concurrency key: ->(language_id, content_id, content_type) { "#{language_id}-#{content_type}-#{content_id}" }
+  limits_concurrency to: 2, key: ->(language_id, content_id, content_type) { language_id.to_s }
 
   retry_on AzureFileShares::Errors::ApiError, wait: :exponentially_longer, attempts: 3
   retry_on Timeout::Error, wait: :exponentially_longer, attempts: 2


### PR DESCRIPTION
Fixes staging server crashes caused by too many concurrent FileUploadJobs.

Issue: PR #341 fixed the argument bug, but using all 3 arguments (language_id-content_type-content_id) in the concurrency key makes each job unique, so jobs don't queue up. All jobs are queued at the same time from another job, and given the unique keys they run concurrently, crashing the server (saw 30+ in the logs).

Fix: Group jobs by language_id only with limit of 2 concurrent jobs per language.

Before: 30+ jobs run concurrently → server crash
After: Max 4 jobs (2 languages × 2 jobs each)