### PR TITLE
Revert "Batch xml generation and hard-limit running jobs"

### DIFF
--- a/app/jobs/file_upload_job.rb
+++ b/app/jobs/file_upload_job.rb
@@ -1,8 +1,7 @@
 class FileUploadJob < ApplicationJob
   # Consider removing concurrency limits due to SolidQueue blocking issues
   # or use a more specific key to avoid blocking all jobs for a language
-  limits_concurrency to: 2, key: ->(language_id, content_id, content_type) { language_id.to_s }
-
+  limits_concurrency to: 3, key: ->(_language_id, content_id, _content_type) { "hard-limit" }
   retry_on AzureFileShares::Errors::ApiError, wait: :exponentially_longer, attempts: 3
   retry_on Timeout::Error, wait: :exponentially_longer, attempts: 2
 

--- a/app/jobs/file_upload_job.rb
+++ b/app/jobs/file_upload_job.rb
@@ -1,7 +1,7 @@
 class FileUploadJob < ApplicationJob
   # Consider removing concurrency limits due to SolidQueue blocking issues
   # or use a more specific key to avoid blocking all jobs for a language
-  limits_concurrency to: 3, key: ->(_language_id, content_id, _content_type) { "hard-limit" }
+  limits_concurrency to: 2, key: ->(language_id, content_id, content_type) { language_id.to_s }
 
   retry_on AzureFileShares::Errors::ApiError, wait: :exponentially_longer, attempts: 3
   retry_on Timeout::Error, wait: :exponentially_longer, attempts: 2

--- a/app/jobs/language_files_job.rb
+++ b/app/jobs/language_files_job.rb
@@ -1,6 +1,4 @@
 class LanguageFilesJob < ApplicationJob
-  limits_concurrency to: 1, key: ->(language_id) { "hard-limit" }
-
   def perform(language_id)
     language = Language.find(language_id)
     LanguageContentProcessor.new(language).perform

--- a/app/services/xml_generator/all_providers.rb
+++ b/app/services/xml_generator/all_providers.rb
@@ -7,22 +7,12 @@ class XmlGenerator::AllProviders < XmlGenerator::SingleProvider
   attr_reader :language, :args
 
   def xml_content(xml)
-    # Avoid building a massive join result; iterate provider ids in small slices.
-    ActiveRecord::Base.uncached do
-      provider_ids_in_language_in_batches do |ids|
-        Provider.where(id: ids).order(:id).each do |provider|
-          xml << provider_xml(provider) # provider_xml should eager-load topics/attachments per provider
-        end
+    language.providers
+      .select("providers.id, providers.name, topics.id AS topic_id, topics.title AS topic_title, topics.created_at AS topic_created_at")
+      .joins(:topics)
+      .merge(Topic.with_attached_documents)
+      .each do |provider|
+        xml << provider_xml(provider)
       end
-    end
-  end
-
-  private
-
-  # Yields slices of provider ids that have topics in this language.
-  def provider_ids_in_language_in_batches(batch_size: 500)
-    Topic.where(language_id: language.id).distinct.pluck(:provider_id).each_slice(batch_size) do |ids|
-      yield ids
-    end
   end
 end


### PR DESCRIPTION
This reverts commit d6cc3501c0ce9c511e3d51109e3d5850f48b30a7.

The batch PR fixed performance but broke the structure of the XML. Reverting so we can work from the clean, working (but not performing) state.