### PR TITLE
Stop XML files generation for providers

### DIFF
--- a/app/services/language_content_processor.rb
+++ b/app/services/language_content_processor.rb
@@ -82,8 +82,8 @@ class LanguageContentProcessor
       FileUploadJob.perform_later(language.id, file_id.to_s, "file")
     end
 
-    language.providers.distinct.find_each do |provider|
-      FileUploadJob.perform_later(language.id, provider.id, "provider")
-    end
+    # language.providers.distinct.find_each do |provider|
+    #   FileUploadJob.perform_later(language.id, provider.id, "provider")
+    # end
   end
 end

--- a/spec/services/language_content_processor_spec.rb
+++ b/spec/services/language_content_processor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe LanguageContentProcessor do
   end
 
   it "processes content for every language" do
-    files_number = language.providers.size + 7 # 2 xml files for all provides, 2 text files for tags, 5 csv files
+    files_number = language.providers.size + 6 # 2 xml files for all providers, 1 xml file for single provider, 2 text files for tags, 5 csv files
     subject.perform
 
     expect(FileUploadJob).to have_received(:perform_later).exactly(files_number).times
@@ -29,6 +29,6 @@ RSpec.describe LanguageContentProcessor do
     expect(FileUploadJob).to have_received(:perform_later).with(language.id, "tag_details", "file")
     expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topic_tags", "file")
     expect(FileUploadJob).to have_received(:perform_later).with(language.id, "topic_authors", "file")
-    expect(FileUploadJob).to have_received(:perform_later).with(language.id, provider.id, "provider")
+    # expect(FileUploadJob).to have_received(:perform_later).with(language.id, provider.id, "provider")
   end
 end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Discussed on Slack with @dcollie2. This is a temporary measure while we fix issues with XML files.

### What Changed? And Why Did It Change?
It stops generation of XML files for single providers.

### How Has This Been Tested?
With RSpec

### Please Provide Screenshots
N/A

### Additional Comments
N/A
