### PR TITLE
Fix tag deletion flow + footer on Tag show page

### DIFF
--- a/app/views/tags/destroy.turbo_stream.erb
+++ b/app/views/tags/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.update "delete_tag_#{@tag.id}" do %>
-  <div class="confirmation-dialog">
+  <div class="confirmation-dialog mt-4">
     <h5>Are you sure you want to delete this tag?</h5>
 
     <div class="mt-4 hstack gap-3">
@@ -7,7 +7,7 @@
         <%= button_to "Confirm Delete", tag_path(@tag, confirmed: true),  method: :delete, class: "btn btn-danger" %>
       </div>
       <div>
-        <%= link_to "Cancel", tags_path, class: "btn btn-secondary" %>
+        <%= link_to "Cancel", tag_path(@tag), class: "btn btn-secondary" %>
       </div>
     </div>
   </div>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -2,13 +2,12 @@
 
 <%= render @tag %>
 
-<div id="<%= "delete_tag_#{@tag.id}" %>">
-  <%= link_to "Back to tags", tags_path, class: "mt-4" %>
+<%= link_to "Back to tags", tags_path, class: "mt-4" %>
 
 <div>
   <%= link_to "Edit this tag", edit_tag_path(@tag), class: "btn btn-primary mt-4" %>
 </div>
 
-<div>
+<div id="<%= "delete_tag_#{@tag.id}" %>">
   <%= button_to "Delete this tag", @tag, method: :delete, class: "btn btn-danger mt-4" %>
 </div>


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves an issue I noticed while looking into Tags

### What Changed? And Why Did It Change?

There were 2 issues on the Tag #show page:

- The footer was not at the bottom of the page
- When clicking on "Cancel" after clicking on "Delete this tag", the user was taken out of the page

This PR fixes these issues.

### How Has This Been Tested?
By hand

### Please Provide Screenshots
Before:

https://github.com/user-attachments/assets/814041ad-f69c-47e6-924a-8160e879ed92

After:

https://github.com/user-attachments/assets/2eca3314-cf0a-48db-8c71-0bf212863d50




### Additional Comments
