### PR TITLE
Use active state for search params by default

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -105,7 +105,7 @@ class TopicsController < ApplicationController
   end
 
   def search_params
-    return {} unless params[:search].present?
+    return { state: :active } unless params[:search].present?
 
     params.require(:search).permit(:query, :state, :language_id, :year, :month, :order, tag_list: [])
   end

--- a/app/views/topics/_list.html.erb
+++ b/app/views/topics/_list.html.erb
@@ -9,7 +9,7 @@
       <td class="text-bold-500"><%= topic.documents.size %></td>
       <td class="text-bold-500"><span class="badge <%= topic.state == "active" ? "bg-success" : "bg-light-danger" %>"><%= topic.state %></span></td>
       <td class="text-end">
-        <%= link_to topic_path(topic, search: search_params), class: "btn btn-primary btn-sm", data: { turbo: false } do %>
+        <%= link_to topic_path(topic, search: search_params), class: "btn btn-primary btn-sm", data: { testid: topic.id, turbo: false } do %>
           <i class="bi bi-search"></i> View
         <% end %>
         <%= link_to edit_topic_path(topic), class: "btn btn-secondary btn-sm", data: { turbo: false } do %>

--- a/spec/system/topics/search_spec.rb
+++ b/spec/system/topics/search_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Topics search", type: :system do
     it "shows all topics from first provider" do
       expect(page).to have_text(english_active_topic.title)
       expect(page).to have_text(spanish_active_topic.title)
-      expect(page).to have_text(english_archived_topic.title)
+      expect(page).not_to have_text(english_archived_topic.title)
     end
 
     context "when searching by title" do
@@ -99,7 +99,7 @@ RSpec.describe "Topics search", type: :system do
         select "English", from: "search_language_id"
 
         expect(page).to have_text(english_active_topic.title)
-        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
         expect(page).not_to have_text(spanish_active_topic.title)
       end
     end
@@ -114,7 +114,7 @@ RSpec.describe "Topics search", type: :system do
 
         select "2023", from: "search_year"
 
-        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
         expect(page).not_to have_text(spanish_active_topic.title)
         expect(page).not_to have_text(english_active_topic.title)
       end
@@ -125,7 +125,7 @@ RSpec.describe "Topics search", type: :system do
         select "2", from: "search_month"
 
         expect(page).to have_text(spanish_active_topic.title)
-        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
         expect(page).not_to have_text(english_active_topic.title)
 
         select "3", from: "search_month"
@@ -165,13 +165,15 @@ RSpec.describe "Topics search", type: :system do
     context "when sorting" do
       it "displays users in the selected order" do
         select "asc", from: "search_order"
-        expect(page).to have_text(/#{english_archived_topic.title}.+#{spanish_active_topic.title}.+#{english_active_topic.title}/m)
+
+        expect(page).to have_text(/#{spanish_active_topic.title}.+#{english_active_topic.title}/m)
       end
     end
 
     context "when switching to another provider" do
       it "only shows topics from the selected provider" do
         select provider_2.name, from: "provider_id"
+
         expect(page).to have_text(other_provider_topic.title)
         expect(page).not_to have_text(english_active_topic.title)
         expect(page).not_to have_text(spanish_active_topic.title)
@@ -196,7 +198,7 @@ RSpec.describe "Topics search", type: :system do
       it "only shows topics from its first associated provider" do
         expect(page).to have_text(english_active_topic.title)
         expect(page).to have_text(spanish_active_topic.title)
-        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
         expect(page).not_to have_text(other_provider_topic.title)
       end
 
@@ -231,7 +233,7 @@ RSpec.describe "Topics search", type: :system do
           select "English", from: "search_language_id"
 
           expect(page).to have_text(english_active_topic.title)
-          expect(page).to have_text(english_archived_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
           expect(page).not_to have_text(spanish_active_topic.title)
         end
       end
@@ -246,7 +248,7 @@ RSpec.describe "Topics search", type: :system do
 
           select "2023", from: "search_year"
 
-          expect(page).to have_text(english_archived_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
           expect(page).not_to have_text(spanish_active_topic.title)
           expect(page).not_to have_text(english_active_topic.title)
         end
@@ -257,7 +259,7 @@ RSpec.describe "Topics search", type: :system do
           select "2", from: "search_month"
 
           expect(page).to have_text(spanish_active_topic.title)
-          expect(page).to have_text(english_archived_topic.title)
+          expect(page).not_to have_text(english_archived_topic.title)
           expect(page).not_to have_text(english_active_topic.title)
 
           select "3", from: "search_month"
@@ -297,7 +299,7 @@ RSpec.describe "Topics search", type: :system do
       context "when sorting" do
         it "displays users in the selected order" do
           select "asc", from: "search_order"
-          expect(page).to have_text(/#{english_archived_topic.title}.+#{spanish_active_topic.title}.+#{english_active_topic.title}/m)
+          expect(page).to have_text(/#{spanish_active_topic.title}.+#{english_active_topic.title}/m)
         end
       end
     end
@@ -311,7 +313,7 @@ RSpec.describe "Topics search", type: :system do
       it "only shows topics from its first associated provider" do
         expect(page).to have_text(english_active_topic.title)
         expect(page).to have_text(spanish_active_topic.title)
-        expect(page).to have_text(english_archived_topic.title)
+        expect(page).not_to have_text(english_archived_topic.title)
         expect(page).not_to have_text(other_provider_topic.title)
       end
 

--- a/spec/system/upload_management_spec.rb
+++ b/spec/system/upload_management_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe "Upload Management", type: :system do
   let(:admin) { create(:user, :admin, email: "admin@mail.com") }
 
   before do
-    login_as(admin)
     create(:language)
+    login_as(admin)
   end
 
   context "when creating a new topic" do
@@ -49,7 +49,7 @@ RSpec.describe "Upload Management", type: :system do
         expect(page).to have_text("logo_ruby_for_good.png")
         expect(page).to have_text("skillrx_sidebar.png")
         click_button("Update Topic")
-        click_link("View", href: topic_path(topic))
+        find_link { |l| l["data-testid"] == "#{topic.id}" }.click
         expect(page).to have_text("skillrx_sidebar.png")
       end
 
@@ -62,7 +62,7 @@ RSpec.describe "Upload Management", type: :system do
           expect(page).to have_text("logo_ruby_for_good.png")
           expect(page).to have_text("skillrx_sidebar.png")
           click_link("Cancel")
-          click_link("View", href: topic_path(topic))
+          find_link { |l| l["data-testid"] == "#{topic.id}" }.click
           expect(page).to have_text("logo_ruby_for_good.png")
           expect(page).not_to have_text("skillrx_sidebar.png")
         end
@@ -78,7 +78,7 @@ RSpec.describe "Upload Management", type: :system do
           expect(page).to have_text("file_text_test.txt")
           click_button("Update Topic")
           expect(page).to have_text("View")
-          click_link("View", href: topic_path(topic))
+          find_link { |l| l["data-testid"] == "#{topic.id}" }.click
           expect(page).not_to have_text("file_text_test.txt")
         end
       end
@@ -91,7 +91,7 @@ RSpec.describe "Upload Management", type: :system do
         expect(page).not_to have_text("logo_ruby_for_good.png")
         click_button("Update Topic")
         expect(page).to have_text("View")
-        click_link("View", href: topic_path(topic))
+        find_link { |l| l["data-testid"] == "#{topic.id}" }.click
         expect(page).not_to have_text("logo_ruby_for_good.png")
       end
 
@@ -101,7 +101,7 @@ RSpec.describe "Upload Management", type: :system do
         expect(page).not_to have_text("logo_ruby_for_good.png")
         click_link("Cancel")
         expect(page).to have_text("View")
-        click_link("View", href: topic_path(topic))
+        find_link { |l| l["data-testid"] == "#{topic.id}" }.click
         expect(page).to have_text("logo_ruby_for_good.png")
       end
     end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #251

### What Changed? And Why Did It Change?

This PR introduces default search params for topics. It will show active topic by default

### How Has This Been Tested?

### Please Provide Screenshots

### Additional Comments

I've also introduced data-attribute finders for capybara, so we don't have to rely on texts/labels