### PR TITLE
Change name of new uploads xml file

### DIFF
--- a/app/services/language_content_processor.rb
+++ b/app/services/language_content_processor.rb
@@ -32,7 +32,7 @@ class LanguageContentProcessor
       ),
       all_providers_recent: FileToUpload.new(
         content: ->(language) { XmlGenerator::AllProviders.new(language, recent: true).perform },
-        name: "#{language.file_storage_prefix}New_Uploads_Server_XML.xml",
+        name: "#{language.file_storage_prefix}New_Uploads.xml",
         path: "#{language.file_storage_prefix}CMES-Pi/assets/XML",
       ),
       tags: FileToUpload.new(


### PR DESCRIPTION
This changes the name of the file from new_uploads_server_xml to new_uploads. After this, all XML files will be generating properly.