### PR TITLE
fix: add libyaml-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev pkg-config && \
+    apt-get install --no-install-recommends -y build-essential git libpq-dev libyaml-dev pkg-config && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,6 +12,7 @@ ENV RAILS_ENV=development \
 RUN apk add --no-cache \
     build-base \
     postgresql-dev \
+    yaml-dev \
     git \
     tzdata \
     bash \


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Fixing build for Docker: https://github.com/rubyforgood/skillrx/actions/runs/17920186682/job/50952787970

### What Changed? And Why Did It Change?

Added libyaml explicitly to Dockerfile

### How Has This Been Tested?

### Please Provide Screenshots

### Additional Comments
