### PR TITLE
Add macOS 15 platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -606,6 +606,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-darwin-23
   x86_64-darwin-24
   x86_64-linux


### PR DESCRIPTION
### What Changed? And Why Did It Change?

Adds arm64-darwin-25 platform to Gemfile.lock to support developers running macOS 15 Sequoia on Apple Silicon. Without this entry, Bundler may not resolve dependencies correctly for this platform.

### How Has This Been Tested?

Ran bundle install successfully on macOS 15.