### PR TITLE
fix: switch to weekly updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

We don't need daily updated for dependant. Having weekly updates (like for skillrx-beacon repo) would be Ok.

### What Changed? And Why Did It Change?

Changing update schedule from daily to weekly

### How Has This Been Tested?

### Please Provide Screenshots

### Additional Comments
