### PR TITLE
Set provider prefix on creation and when editing a provider with no topics

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -66,8 +66,12 @@
   box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.1);
 }
 
-.input-field:hover:not(:focus) {
+.input-field:hover:not(:focus):not(:disabled) {
   @apply border-gray-400;
+}
+
+.input-field:disabled {
+  @apply bg-gray-100 text-gray-500;
 }
 
 .select-field {

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -26,4 +26,21 @@ class Provider < ApplicationRecord
 
   validates :name, :provider_type, presence: true
   validates :name, uniqueness: true
+
+  validate :file_name_prefix_may_be_changed, on: :update, if: :file_name_prefix_changed?
+
+  def topics?
+    topics.any?
+  end
+
+  private
+
+  def file_name_prefix_may_be_changed
+    if topics?
+      errors.add(
+        :file_name_prefix,
+        "can't be changed as provider has associated topics and so file names are established"
+      )
+    end
+  end
 end

--- a/app/views/providers/_form.html.erb
+++ b/app/views/providers/_form.html.erb
@@ -2,6 +2,25 @@
   <div class="space-y-6">
     <%= render "shared/errors", errors: provider.errors.full_messages, resource_name: provider.class.name %>
 
+    <!-- File name prefix uneditable notice -->
+    <% if @provider.topics? %>
+      <div id="file-name-prefix-uneditable-notice" class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+        <div class="flex">
+          <div class="flex-shrink-0">
+            <svg class="h-5 w-5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+          </div>
+          <div class="ml-3">
+            <p class="text-sm text-blue-700 m-0">
+              There are topics associated with this provider, so the file names are established and the file name prefix can't be edited.
+            </p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
+
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
       <!-- Provider Name -->
@@ -11,7 +30,7 @@
           <span class="text-red-500">*</span>
         <% end %>
         <%= form.text_field :name,
-            placeholder: "Enter provider name (e.g., Johns Hopkins, Mayo Clinic)",
+            placeholder: "e.g., Johns Hopkins, Mayo Clinic",
             autofocus: true,
             class: "input-field bg-gray-50" %>
         <p class="help-text">The official name of the healthcare provider or organization.</p>
@@ -28,6 +47,31 @@
             class: "input-field bg-gray-50" %>
         <p class="help-text">The type or category of healthcare provider.</p>
       </div>
+
+      <!-- File name prefix -->
+      <% if @provider.topics? %>
+        <div>
+          <%= form.label :file_name_prefix, class: "input-label" do %>
+            File name prefix
+          <% end %>
+          <%= form.text_field :file_name_prefix,
+              disabled: true,
+              value: @provider.file_name_prefix,
+              class: "input-field bg-gray-50"
+          %>
+          <p class="help-text">The prefix to use for this provider's uploads.</p>
+        </div>
+      <% else %>
+        <div>
+          <%= form.label :file_name_prefix, class: "input-label" do %>
+            File name prefix
+          <% end %>
+          <%= form.text_field :file_name_prefix,
+              placeholder: "e.g., 123_who_guidelines",
+              class: "input-field bg-gray-50" %>
+          <p class="help-text">The prefix to use for this provider's uploads.</p>
+        </div>
+      <% end %>
 
       <!-- Regions -->
       <div>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -81,7 +81,7 @@
           </div>
 
           <div class="card-body">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
 
               <div>
                 <label class="input-label">Provider Name</label>
@@ -97,7 +97,7 @@
                 </div>
               </div>
 
-              <div>
+              <div class="col-span-full">
                 <label class="input-label">File Name Prefix</label>
                 <div class="bg-gray-50 p-4 rounded-lg border border-gray-200">
                   <% if @provider.file_name_prefix.present? %>

--- a/spec/jobs/documents_sync_job_spec.rb
+++ b/spec/jobs/documents_sync_job_spec.rb
@@ -1,12 +1,10 @@
 require "rails_helper"
 
 RSpec.describe DocumentsSyncJob, type: :job do
-  let(:topic) { create(:topic, :with_documents) }
-  let(:provider) { topic.provider }
+  let(:provider) { create(:provider, file_name_prefix: "MyPrefix") }
+  let(:topic) { create(:topic, :with_documents, provider:) }
   let(:document) { topic.documents.first }
   let(:file_name) { document.filename }
-
-  before { provider.update(file_name_prefix: "MyPrefix") }
 
   describe "#perform" do
     let(:file_worker) { instance_double(FileWorker) }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,0 +1,64 @@
+# == Schema Information
+#
+# Table name: providers
+# Database name: primary
+#
+#  id               :bigint           not null, primary key
+#  file_name_prefix :string
+#  name             :string
+#  provider_type    :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  old_id           :integer
+#
+# Indexes
+#
+#  index_providers_on_old_id  (old_id) UNIQUE
+#
+require "rails_helper"
+
+RSpec.describe Provider, type: :model do
+  let(:provider) { create(:provider) }
+  subject { provider }
+
+  describe "validations" do
+    it { should validate_presence_of(:provider_type) }
+    it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name) }
+
+    describe "#file_name_prefix_may_be_changed" do
+      context "when a provider has topics" do
+        let!(:topic) { create(:topic, provider: provider) }
+
+        it "returns an error" do
+          provider.file_name_prefix = "updated_prefix"
+          expect(provider).not_to be_valid
+          expect(provider.errors[:file_name_prefix]).to match_array(
+            "can't be changed as provider has associated topics and so file names are established"
+          )
+        end
+      end
+
+      context "when a provider has no topics" do
+        it "does not return an error" do
+          provider.file_name_prefix = "updated_prefix"
+          expect(provider).to be_valid
+        end
+      end
+    end
+  end
+
+  describe "#topics?" do
+    subject { provider.topics? }
+
+    context "when a provider has topics" do
+      let!(:topic) { create(:topic, provider: provider) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when a provider has no topics" do
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/views/providers/edit.html.erb_spec.rb
+++ b/spec/views/providers/edit.html.erb_spec.rb
@@ -16,4 +16,28 @@ RSpec.describe "providers/edit", type: :view do
       assert_select "input[type='submit'][value='Update Provider']"
     end
   end
+
+  context "when the provider has associated topics" do
+    before { create(:topic, provider: provider) }
+
+    it "tells the user that the File name prefix can't be changed" do
+      render
+
+      assert_select "form[action=?][method=?]", provider_path(provider), "post" do
+        assert_select "input[name=?][disabled]", "provider[file_name_prefix]"
+      end
+
+      assert_select "div#file-name-prefix-uneditable-notice"
+    end
+  end
+
+  context "when the provider that has no associated topics" do
+    it "has the File name prefix field" do
+      render
+
+      assert_select "form[action=?][method=?]", provider_path(provider), "post" do
+        assert_select "input[name=?]", "provider[file_name_prefix]"
+      end
+    end
+  end
 end

--- a/spec/views/providers/new.html.erb_spec.rb
+++ b/spec/views/providers/new.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "providers/new", type: :view do
     assert_select "form[action=?][method=?]", providers_path, "post" do
       assert_select "input[name=?]", "provider[name]"
       assert_select "input[name=?]", "provider[provider_type]"
+      assert_select "input[name=?]", "provider[file_name_prefix]"
       assert_select "input[type='submit'][value='Create Provider']"
     end
   end


### PR DESCRIPTION
# What Issue Does This PR Cover, If Any?

Resolves #607 

### What Changed? And Why Did It Change?

Each provider has a `file_name_prefix`. This value is added to the file name 
when the provider uploads a file. This `file_name_prefix` is necessary 
to coordinate between our file storage and Azure's. However, if a provider 
was to change their `file_name_prefix` when they had uploaded files, 
it would break management of those existing uploaded files. 

Before, we got around this by simply removing the field from the provider's
form. This meant that users could not set the value of `file_name_prefix`
when making a new provider or when editing a provider who had no uploaded
files. 

This PR adds the ability to set the `file_name_prefix` value on the
provider form. The field will show on the form when the provider
is...
- A new instance
- One who has no topics, and no uploaded files

### How Has This Been Tested?
RSpec and by verifying these test cases by hand...
- [x] When I am creating a new provider, I can see and set
the `file_name_prefix` field
- [x] When I am editing a provider without topics, I can see 
and set the `file_name_prefix` field
- [x] When I am editing a provider with topics, I cannot see 
and set the `file_name_prefix` field

### Please Provide Screenshots
<img width="3024" height="1898" alt="The provider form, with the `file_name_prefix`, for a new instance" src="https://github.com/user-attachments/assets/64f28f2f-52fc-4106-97db-95bc3d08ea34" />

_The provider form, with the `file_name_prefix`, for a new instance_

<img width="3024" height="1898" alt="The provider form, with the `file_name_prefix`, for editing an instance with no topics" src="https://github.com/user-attachments/assets/9dd2096b-32d6-4047-90a8-410ae7bddcca" />

_The provider form, with the `file_name_prefix`, for editing an instance with no topics_

<img width="3024" height="1898" alt="The provider form, with a disabled `file_name_prefix`, because the provider being edited has topics" src="https://github.com/user-attachments/assets/af97d28e-c813-451e-8c03-66e5da618cad"  />

_The provider form, with a disabled `file_name_prefix`, because the provider being edited has topics_

